### PR TITLE
feat: add scheduler agent service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,13 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+  scheduler-agent:
+    build: ./services/scheduler-agent
+    environment:
+      - RABBIT_URL=amqp://guest:guest@rabbitmq:5672
+      - ORDER_URL=http://order-service:8080
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      order-service:
+        condition: service_healthy

--- a/services/scheduler-agent/Dockerfile
+++ b/services/scheduler-agent/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py ./
+CMD ["python", "app.py"]

--- a/services/scheduler-agent/app.py
+++ b/services/scheduler-agent/app.py
@@ -1,0 +1,34 @@
+import json
+import os
+
+import pika
+import requests
+
+RABBIT_URL = os.environ.get("RABBIT_URL", "amqp://guest:guest@localhost:5672")
+ORDER_URL = os.environ.get("ORDER_URL", "http://localhost:8080")
+QUEUE_NAME = "order.created"
+
+
+def on_message(channel, method, properties, body):
+    try:
+        data = json.loads(body)
+        order_id = data.get("id")
+        if not order_id:
+            return
+        requests.post(f"{ORDER_URL}/orders/{order_id}/confirm")
+    finally:
+        channel.basic_ack(delivery_tag=method.delivery_tag)
+
+
+def main():
+    params = pika.URLParameters(RABBIT_URL)
+    connection = pika.BlockingConnection(params)
+    channel = connection.channel()
+    channel.queue_declare(queue=QUEUE_NAME, durable=True)
+    channel.basic_consume(queue=QUEUE_NAME, on_message_callback=on_message)
+    print(f"Listening on {QUEUE_NAME} queue...")
+    channel.start_consuming()
+
+
+if __name__ == "__main__":
+    main()

--- a/services/scheduler-agent/requirements.txt
+++ b/services/scheduler-agent/requirements.txt
@@ -1,0 +1,2 @@
+pika
+requests


### PR DESCRIPTION
## Summary
- add Python-based scheduler agent consuming `order.created` events and confirming orders
- containerize scheduler agent and expose `RABBIT_URL` and `ORDER_URL` configuration
- wire scheduler agent into docker-compose

## Testing
- `python -m py_compile services/scheduler-agent/app.py`
- `mvn -q -f services/order-service/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f3c34208832ea1d00c1462d6c206