### PR TITLE
Add BDD scenarios for invalid order cases

### DIFF
--- a/tests/bdd/features/order_event.feature
+++ b/tests/bdd/features/order_event.feature
@@ -3,3 +3,13 @@ Feature: Order events
     Given the order service is running
     When I create an order
     Then an "order.created" event should be published
+
+  Scenario: failing to create order with nonexistent product
+    Given the order service is running
+    When I try to create an order with product "unknown" and quantity 1
+    Then the response status should be 404
+
+  Scenario: failing to create order with invalid quantity
+    Given the order service is running
+    When I try to create an order with product "p1" and quantity 0
+    Then the response status should be 400

--- a/tests/bdd/features/steps/order.steps.ts
+++ b/tests/bdd/features/steps/order.steps.ts
@@ -5,6 +5,7 @@ import assert from 'assert';
 
 let connection: any;
 let lastOrderId: string;
+let lastResponse: any;
 
 Given('the order service is running', async function () {
   connection = await amqp.connect(process.env.RABBIT_URL || 'amqp://localhost');
@@ -16,6 +17,19 @@ Given('the order service is running', async function () {
 When('I create an order', async function () {
   const res = await axios.post('http://localhost:8080/orders', { productId: 'p1', quantity: 1 });
   lastOrderId = res.data.id;
+});
+
+When('I try to create an order with product {string} and quantity {int}', async function (productId: string, quantity: number) {
+  try {
+    const res = await axios.post('http://localhost:8080/orders', { productId, quantity });
+    lastResponse = res;
+  } catch (err: any) {
+    if (err.response) {
+      lastResponse = err.response;
+    } else {
+      throw err;
+    }
+  }
 });
 
 Then('an {string} event should be published', async function (routingKey: string) {
@@ -34,4 +48,9 @@ Then('an {string} event should be published', async function (routingKey: string
   assert.ok(msg, 'No message received');
   const content = JSON.parse(msg!.content.toString());
   assert.strictEqual(content.id, lastOrderId);
+});
+
+Then('the response status should be {int}', async function (status: number) {
+  assert.strictEqual(lastResponse?.status, status);
+  await connection.close();
 });


### PR DESCRIPTION
## Summary
- expand order BDD tests with scenarios for nonexistent products and invalid quantities
- implement corresponding step definitions checking HTTP status responses

## Testing
- `npm test` *(fails: ECONNREFUSED connecting to RabbitMQ)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f3c70384832ea6fd30e5a25e069a