### PR TITLE
feat: add order confirmation endpoint

### DIFF
--- a/services/order-service/src/main/java/com/shop/order/application/ConfirmOrderService.java
+++ b/services/order-service/src/main/java/com/shop/order/application/ConfirmOrderService.java
@@ -1,0 +1,22 @@
+package com.shop.order.application;
+
+import com.shop.order.domain.Order;
+import com.shop.order.infrastructure.OrderRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ConfirmOrderService {
+    private final OrderRepository repository;
+
+    public ConfirmOrderService(OrderRepository repository) {
+        this.repository = repository;
+    }
+
+    public Order confirm(String id) {
+        Order order = repository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Order not found"));
+        order.setStatus("CONFIRMED");
+        repository.update(order);
+        return order;
+    }
+}

--- a/services/order-service/src/main/java/com/shop/order/infrastructure/InMemoryOrderRepository.java
+++ b/services/order-service/src/main/java/com/shop/order/infrastructure/InMemoryOrderRepository.java
@@ -3,6 +3,7 @@ package com.shop.order.infrastructure;
 import com.shop.order.domain.Order;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
@@ -11,6 +12,16 @@ public class InMemoryOrderRepository implements OrderRepository {
 
     @Override
     public void save(Order order) {
+        orders.put(order.getId(), order);
+    }
+
+    @Override
+    public Optional<Order> findById(String id) {
+        return Optional.ofNullable(orders.get(id));
+    }
+
+    @Override
+    public void update(Order order) {
         orders.put(order.getId(), order);
     }
 }

--- a/services/order-service/src/main/java/com/shop/order/infrastructure/OrderRepository.java
+++ b/services/order-service/src/main/java/com/shop/order/infrastructure/OrderRepository.java
@@ -2,6 +2,10 @@ package com.shop.order.infrastructure;
 
 import com.shop.order.domain.Order;
 
+import java.util.Optional;
+
 public interface OrderRepository {
     void save(Order order);
+    Optional<Order> findById(String id);
+    void update(Order order);
 }

--- a/services/order-service/src/main/java/com/shop/order/interfaces/OrderController.java
+++ b/services/order-service/src/main/java/com/shop/order/interfaces/OrderController.java
@@ -1,5 +1,6 @@
 package com.shop.order.interfaces;
 
+import com.shop.order.application.ConfirmOrderService;
 import com.shop.order.application.CreateOrderService;
 import com.shop.order.domain.Order;
 import com.shop.order.infrastructure.OrderEventPublisher;
@@ -12,10 +13,12 @@ import org.springframework.web.bind.annotation.*;
 public class OrderController {
     private final CreateOrderService createOrderService;
     private final OrderEventPublisher eventPublisher;
+    private final ConfirmOrderService confirmOrderService;
 
-    public OrderController(CreateOrderService createOrderService, OrderEventPublisher eventPublisher) {
+    public OrderController(CreateOrderService createOrderService, OrderEventPublisher eventPublisher, ConfirmOrderService confirmOrderService) {
         this.createOrderService = createOrderService;
         this.eventPublisher = eventPublisher;
+        this.confirmOrderService = confirmOrderService;
     }
 
     @PostMapping
@@ -23,6 +26,12 @@ public class OrderController {
         Order order = createOrderService.create(request.productId(), request.quantity());
         eventPublisher.publish(order);
         return ResponseEntity.status(HttpStatus.CREATED).body(new OrderResponse(order.getId()));
+    }
+
+    @PostMapping("/{id}/confirm")
+    public ResponseEntity<Void> confirm(@PathVariable String id) {
+        confirmOrderService.confirm(id);
+        return ResponseEntity.ok().build();
     }
 
     public record CreateOrderRequest(String productId, int quantity) {}


### PR DESCRIPTION
## Summary
- add service to confirm orders
- expose POST /orders/{id}/confirm endpoint
- extend order repository with lookup and update

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f72c5378832e9670362c653a8bde