### PR TITLE
Add CI automation and module tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install Python dependencies
+        run: pip install -r services/workers/scheduler-agent/requirements-dev.txt
+      - name: Install BDD dependencies
+        run: |
+          cd tests/bdd
+          npm install
+      - name: Run linters
+        run: make lint
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install Python dependencies
+        run: pip install -r services/workers/scheduler-agent/requirements-dev.txt
+      - name: Install BDD dependencies
+        run: |
+          cd tests/bdd
+          npm install
+      - name: Run tests
+        run: make test
+
+  security:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install Python dependencies
+        run: pip install -r services/workers/scheduler-agent/requirements-dev.txt
+      - name: Security checks
+        run: make security

--- a/Makefile
+++ b/Makefile
@@ -3,22 +3,37 @@ SCHEDULER_DIR := services/workers/scheduler-agent
 BDD_DIR := tests/bdd
 LLM_DIR := ml/llm
 
-.PHONY: help compose-up compose-down compose-logs api-build api-test api-run         worker-install worker-run bdd-install bdd-test llm-setup llm-notebook
+.PHONY: help compose-up compose-down compose-logs lint test security         api-build api-test api-run api-lint         worker-install worker-run worker-lint worker-test         bdd-install bdd-test bdd-lint         llm-setup llm-notebook
 
 help:
 	@echo "Targets disponíveis:"
 	@echo "  compose-up       - Sobe toda a stack com Docker Compose"
 	@echo "  compose-down     - Derruba a stack e remove volumes"
 	@echo "  compose-logs     - Segue os logs de todos os serviços"
+	@echo "  lint             - Executa linters e formatadores de todos os módulos"
+	@echo "  test             - Executa testes unitários dos módulos"
+	@echo "  security         - Roda checagens de segurança"
 	@echo "  api-build        - Executa mvn clean install no order-service"
 	@echo "  api-test         - Executa mvn test no order-service"
+	@echo "  api-lint         - Executa validação de formato (Spotless) no order-service"
 	@echo "  api-run          - Sobe o order-service localmente"
-	@echo "  worker-install   - Instala dependências do scheduler-agent"
+	@echo "  worker-install   - Instala dependências (dev) do scheduler-agent"
 	@echo "  worker-run       - Inicia o scheduler-agent localmente"
+	@echo "  worker-lint      - Executa black/ruff no scheduler-agent"
+	@echo "  worker-test      - Executa pytest no scheduler-agent"
 	@echo "  bdd-install      - Instala dependências dos testes BDD"
 	@echo "  bdd-test         - Executa npm test em tests/bdd"
+	@echo "  bdd-lint         - Executa checagem TypeScript em tests/bdd"
 	@echo "  llm-setup        - Instala dependências dos notebooks de IA/LLM"
 	@echo "  llm-notebook     - Abre Jupyter Lab apontando para ml/llm/notebooks"
+
+lint: api-lint worker-lint bdd-lint
+
+test: api-test worker-test
+
+security:
+	bandit -q -r $(SCHEDULER_DIR)
+	cd $(BDD_DIR) && npm audit --omit=dev
 
 compose-up:
 	docker compose up -d
@@ -35,20 +50,33 @@ api-build:
 api-test:
 	mvn -f $(ORDER_SERVICE_DIR)/pom.xml test
 
+api-lint:
+	mvn -f $(ORDER_SERVICE_DIR)/pom.xml spotless:check
+
 api-run:
 	mvn -f $(ORDER_SERVICE_DIR)/pom.xml spring-boot:run
 
 worker-install:
-	pip install -r $(SCHEDULER_DIR)/requirements.txt
+	pip install -r $(SCHEDULER_DIR)/requirements-dev.txt
 
 worker-run:
 	python $(SCHEDULER_DIR)/app.py
+
+worker-lint:
+	black --check $(SCHEDULER_DIR)
+	ruff check $(SCHEDULER_DIR)
+
+worker-test:
+	PYTHONPATH=$(SCHEDULER_DIR) pytest $(SCHEDULER_DIR)/tests
 
 bdd-install:
 	cd $(BDD_DIR) && npm install
 
 bdd-test:
 	cd $(BDD_DIR) && npm test
+
+bdd-lint:
+	cd $(BDD_DIR) && npm run lint
 
 llm-setup:
 	pip install -r $(LLM_DIR)/requirements.txt

--- a/services/api/order-service/pom.xml
+++ b/services/api/order-service/pom.xml
@@ -42,6 +42,18 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>2.43.0</version>
+        <configuration>
+          <java>
+            <googleJavaFormat>
+              <version>1.17.0</version>
+            </googleJavaFormat>
+          </java>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/services/api/order-service/src/main/java/com/shop/order/OrderApplication.java
+++ b/services/api/order-service/src/main/java/com/shop/order/OrderApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class OrderApplication {
-    public static void main(String[] args) {
-        SpringApplication.run(OrderApplication.class, args);
-    }
+  public static void main(String[] args) {
+    SpringApplication.run(OrderApplication.class, args);
+  }
 }

--- a/services/api/order-service/src/main/java/com/shop/order/application/ConfirmOrderService.java
+++ b/services/api/order-service/src/main/java/com/shop/order/application/ConfirmOrderService.java
@@ -6,17 +6,17 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class ConfirmOrderService {
-    private final OrderRepository repository;
+  private final OrderRepository repository;
 
-    public ConfirmOrderService(OrderRepository repository) {
-        this.repository = repository;
-    }
+  public ConfirmOrderService(OrderRepository repository) {
+    this.repository = repository;
+  }
 
-    public Order confirm(String id) {
-        Order order = repository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Order not found"));
-        order.setStatus("CONFIRMED");
-        repository.update(order);
-        return order;
-    }
+  public Order confirm(String id) {
+    Order order =
+        repository.findById(id).orElseThrow(() -> new IllegalArgumentException("Order not found"));
+    order.setStatus("CONFIRMED");
+    repository.update(order);
+    return order;
+  }
 }

--- a/services/api/order-service/src/main/java/com/shop/order/application/CreateOrderService.java
+++ b/services/api/order-service/src/main/java/com/shop/order/application/CreateOrderService.java
@@ -6,15 +6,15 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class CreateOrderService {
-    private final OrderRepository repository;
+  private final OrderRepository repository;
 
-    public CreateOrderService(OrderRepository repository) {
-        this.repository = repository;
-    }
+  public CreateOrderService(OrderRepository repository) {
+    this.repository = repository;
+  }
 
-    public Order create(String productId, int quantity) {
-        Order order = new Order(productId, quantity);
-        repository.save(order);
-        return order;
-    }
+  public Order create(String productId, int quantity) {
+    Order order = new Order(productId, quantity);
+    repository.save(order);
+    return order;
+  }
 }

--- a/services/api/order-service/src/main/java/com/shop/order/domain/Order.java
+++ b/services/api/order-service/src/main/java/com/shop/order/domain/Order.java
@@ -3,21 +3,35 @@ package com.shop.order.domain;
 import java.util.UUID;
 
 public class Order {
-    private final String id;
-    private final String productId;
-    private final int quantity;
-    private String status;
+  private final String id;
+  private final String productId;
+  private final int quantity;
+  private String status;
 
-    public Order(String productId, int quantity) {
-        this.id = UUID.randomUUID().toString();
-        this.productId = productId;
-        this.quantity = quantity;
-        this.status = "PENDING";
-    }
+  public Order(String productId, int quantity) {
+    this.id = UUID.randomUUID().toString();
+    this.productId = productId;
+    this.quantity = quantity;
+    this.status = "PENDING";
+  }
 
-    public String getId() { return id; }
-    public String getProductId() { return productId; }
-    public int getQuantity() { return quantity; }
-    public String getStatus() { return status; }
-    public void setStatus(String status) { this.status = status; }
+  public String getId() {
+    return id;
+  }
+
+  public String getProductId() {
+    return productId;
+  }
+
+  public int getQuantity() {
+    return quantity;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
 }

--- a/services/api/order-service/src/main/java/com/shop/order/infrastructure/InMemoryOrderRepository.java
+++ b/services/api/order-service/src/main/java/com/shop/order/infrastructure/InMemoryOrderRepository.java
@@ -1,27 +1,26 @@
 package com.shop.order.infrastructure;
 
 import com.shop.order.domain.Order;
-import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public class InMemoryOrderRepository implements OrderRepository {
-    private final ConcurrentHashMap<String, Order> orders = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, Order> orders = new ConcurrentHashMap<>();
 
-    @Override
-    public void save(Order order) {
-        orders.put(order.getId(), order);
-    }
+  @Override
+  public void save(Order order) {
+    orders.put(order.getId(), order);
+  }
 
-    @Override
-    public Optional<Order> findById(String id) {
-        return Optional.ofNullable(orders.get(id));
-    }
+  @Override
+  public Optional<Order> findById(String id) {
+    return Optional.ofNullable(orders.get(id));
+  }
 
-    @Override
-    public void update(Order order) {
-        orders.put(order.getId(), order);
-    }
+  @Override
+  public void update(Order order) {
+    orders.put(order.getId(), order);
+  }
 }

--- a/services/api/order-service/src/main/java/com/shop/order/infrastructure/MessagingConfig.java
+++ b/services/api/order-service/src/main/java/com/shop/order/infrastructure/MessagingConfig.java
@@ -12,30 +12,31 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class MessagingConfig {
-    @Bean
-    public TopicExchange orderExchange() {
-        return new TopicExchange("order.exchange");
-    }
+  @Bean
+  public TopicExchange orderExchange() {
+    return new TopicExchange("order.exchange");
+  }
 
-    @Bean
-    public Queue orderCreatedQueue() {
-        return new Queue("order.created");
-    }
+  @Bean
+  public Queue orderCreatedQueue() {
+    return new Queue("order.created");
+  }
 
-    @Bean
-    public Binding orderCreatedBinding(Queue orderCreatedQueue, TopicExchange orderExchange) {
-        return BindingBuilder.bind(orderCreatedQueue).to(orderExchange).with("order.created");
-    }
+  @Bean
+  public Binding orderCreatedBinding(Queue orderCreatedQueue, TopicExchange orderExchange) {
+    return BindingBuilder.bind(orderCreatedQueue).to(orderExchange).with("order.created");
+  }
 
-    @Bean
-    public Jackson2JsonMessageConverter jacksonConverter() {
-        return new Jackson2JsonMessageConverter();
-    }
+  @Bean
+  public Jackson2JsonMessageConverter jacksonConverter() {
+    return new Jackson2JsonMessageConverter();
+  }
 
-    @Bean
-    public RabbitTemplate rabbitTemplate(ConnectionFactory cf, Jackson2JsonMessageConverter converter) {
-        RabbitTemplate template = new RabbitTemplate(cf);
-        template.setMessageConverter(converter);
-        return template;
-    }
+  @Bean
+  public RabbitTemplate rabbitTemplate(
+      ConnectionFactory cf, Jackson2JsonMessageConverter converter) {
+    RabbitTemplate template = new RabbitTemplate(cf);
+    template.setMessageConverter(converter);
+    return template;
+  }
 }

--- a/services/api/order-service/src/main/java/com/shop/order/infrastructure/OrderEventPublisher.java
+++ b/services/api/order-service/src/main/java/com/shop/order/infrastructure/OrderEventPublisher.java
@@ -6,16 +6,18 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class OrderEventPublisher {
-    private final RabbitTemplate rabbitTemplate;
+  private final RabbitTemplate rabbitTemplate;
 
-    public OrderEventPublisher(RabbitTemplate rabbitTemplate) {
-        this.rabbitTemplate = rabbitTemplate;
-    }
+  public OrderEventPublisher(RabbitTemplate rabbitTemplate) {
+    this.rabbitTemplate = rabbitTemplate;
+  }
 
-    public void publish(Order order) {
-        var event = new OrderCreatedEvent(order.getId(), order.getProductId(), order.getQuantity(), order.getStatus());
-        rabbitTemplate.convertAndSend("order.exchange", "order.created", event);
-    }
+  public void publish(Order order) {
+    var event =
+        new OrderCreatedEvent(
+            order.getId(), order.getProductId(), order.getQuantity(), order.getStatus());
+    rabbitTemplate.convertAndSend("order.exchange", "order.created", event);
+  }
 
-    public record OrderCreatedEvent(String id, String productId, int quantity, String status) {}
+  public record OrderCreatedEvent(String id, String productId, int quantity, String status) {}
 }

--- a/services/api/order-service/src/main/java/com/shop/order/infrastructure/OrderRepository.java
+++ b/services/api/order-service/src/main/java/com/shop/order/infrastructure/OrderRepository.java
@@ -1,11 +1,12 @@
 package com.shop.order.infrastructure;
 
 import com.shop.order.domain.Order;
-
 import java.util.Optional;
 
 public interface OrderRepository {
-    void save(Order order);
-    Optional<Order> findById(String id);
-    void update(Order order);
+  void save(Order order);
+
+  Optional<Order> findById(String id);
+
+  void update(Order order);
 }

--- a/services/api/order-service/src/main/java/com/shop/order/interfaces/OrderController.java
+++ b/services/api/order-service/src/main/java/com/shop/order/interfaces/OrderController.java
@@ -11,29 +11,33 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/orders")
 public class OrderController {
-    private final CreateOrderService createOrderService;
-    private final OrderEventPublisher eventPublisher;
-    private final ConfirmOrderService confirmOrderService;
+  private final CreateOrderService createOrderService;
+  private final OrderEventPublisher eventPublisher;
+  private final ConfirmOrderService confirmOrderService;
 
-    public OrderController(CreateOrderService createOrderService, OrderEventPublisher eventPublisher, ConfirmOrderService confirmOrderService) {
-        this.createOrderService = createOrderService;
-        this.eventPublisher = eventPublisher;
-        this.confirmOrderService = confirmOrderService;
-    }
+  public OrderController(
+      CreateOrderService createOrderService,
+      OrderEventPublisher eventPublisher,
+      ConfirmOrderService confirmOrderService) {
+    this.createOrderService = createOrderService;
+    this.eventPublisher = eventPublisher;
+    this.confirmOrderService = confirmOrderService;
+  }
 
-    @PostMapping
-    public ResponseEntity<OrderResponse> create(@RequestBody CreateOrderRequest request) {
-        Order order = createOrderService.create(request.productId(), request.quantity());
-        eventPublisher.publish(order);
-        return ResponseEntity.status(HttpStatus.CREATED).body(new OrderResponse(order.getId()));
-    }
+  @PostMapping
+  public ResponseEntity<OrderResponse> create(@RequestBody CreateOrderRequest request) {
+    Order order = createOrderService.create(request.productId(), request.quantity());
+    eventPublisher.publish(order);
+    return ResponseEntity.status(HttpStatus.CREATED).body(new OrderResponse(order.getId()));
+  }
 
-    @PostMapping("/{id}/confirm")
-    public ResponseEntity<Void> confirm(@PathVariable String id) {
-        confirmOrderService.confirm(id);
-        return ResponseEntity.ok().build();
-    }
+  @PostMapping("/{id}/confirm")
+  public ResponseEntity<Void> confirm(@PathVariable String id) {
+    confirmOrderService.confirm(id);
+    return ResponseEntity.ok().build();
+  }
 
-    public record CreateOrderRequest(String productId, int quantity) {}
-    public record OrderResponse(String id) {}
+  public record CreateOrderRequest(String productId, int quantity) {}
+
+  public record OrderResponse(String id) {}
 }

--- a/services/api/order-service/src/test/java/com/shop/order/application/ConfirmOrderServiceTest.java
+++ b/services/api/order-service/src/test/java/com/shop/order/application/ConfirmOrderServiceTest.java
@@ -1,0 +1,43 @@
+package com.shop.order.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.shop.order.domain.Order;
+import com.shop.order.infrastructure.OrderRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ConfirmOrderServiceTest {
+
+  @Mock private OrderRepository repository;
+
+  @InjectMocks private ConfirmOrderService service;
+
+  @Test
+  void confirmUpdatesStatusAndPersists() {
+    Order existing = new Order("p1", 1);
+    when(repository.findById(existing.getId())).thenReturn(Optional.of(existing));
+
+    Order confirmed = service.confirm(existing.getId());
+
+    assertThat(confirmed.getStatus()).isEqualTo("CONFIRMED");
+    verify(repository).update(existing);
+  }
+
+  @Test
+  void confirmThrowsWhenOrderIsMissing() {
+    when(repository.findById("missing")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.confirm("missing"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Order not found");
+  }
+}

--- a/services/api/order-service/src/test/java/com/shop/order/application/CreateOrderServiceTest.java
+++ b/services/api/order-service/src/test/java/com/shop/order/application/CreateOrderServiceTest.java
@@ -1,0 +1,31 @@
+package com.shop.order.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.shop.order.domain.Order;
+import com.shop.order.infrastructure.OrderRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CreateOrderServiceTest {
+
+  @Mock private OrderRepository repository;
+
+  @InjectMocks private CreateOrderService service;
+
+  @Test
+  void createPersistsOrderAndReturnsInstance() {
+    Order order = service.create("p1", 2);
+
+    verify(repository).save(order);
+    assertThat(order.getProductId()).isEqualTo("p1");
+    assertThat(order.getQuantity()).isEqualTo(2);
+    assertThat(order.getStatus()).isEqualTo("PENDING");
+    assertThat(order.getId()).isNotBlank();
+  }
+}

--- a/services/api/order-service/src/test/java/com/shop/order/interfaces/OrderControllerTest.java
+++ b/services/api/order-service/src/test/java/com/shop/order/interfaces/OrderControllerTest.java
@@ -1,0 +1,61 @@
+package com.shop.order.interfaces;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shop.order.application.ConfirmOrderService;
+import com.shop.order.application.CreateOrderService;
+import com.shop.order.domain.Order;
+import com.shop.order.infrastructure.OrderEventPublisher;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(OrderController.class)
+class OrderControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @MockBean private CreateOrderService createOrderService;
+
+  @MockBean private OrderEventPublisher orderEventPublisher;
+
+  @MockBean private ConfirmOrderService confirmOrderService;
+
+  @Test
+  void createReturnsCreatedAndPublishesEvent() throws Exception {
+    Order order = new Order("p1", 1);
+    when(createOrderService.create(eq("p1"), eq(1))).thenReturn(order);
+
+    var request = new OrderController.CreateOrderRequest("p1", 1);
+
+    mockMvc
+        .perform(
+            post("/orders")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").value(order.getId()));
+
+    verify(orderEventPublisher).publish(order);
+  }
+
+  @Test
+  void confirmReturnsOkWhenServiceCompletes() throws Exception {
+    var orderId = "order-123";
+
+    mockMvc.perform(post("/orders/{id}/confirm", orderId)).andExpect(status().isOk());
+
+    verify(confirmOrderService).confirm(orderId);
+  }
+}

--- a/services/workers/scheduler-agent/pyproject.toml
+++ b/services/workers/scheduler-agent/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["app"]

--- a/services/workers/scheduler-agent/requirements-dev.txt
+++ b/services/workers/scheduler-agent/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+bandit==1.7.9
+black==24.4.2
+pytest==8.2.1
+ruff==0.4.7

--- a/services/workers/scheduler-agent/tests/test_app.py
+++ b/services/workers/scheduler-agent/tests/test_app.py
@@ -1,0 +1,38 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import app
+
+
+def _method(tag: str) -> SimpleNamespace:
+    return SimpleNamespace(delivery_tag=tag)
+
+
+def test_on_message_posts_confirmation_request(monkeypatch):
+    channel = MagicMock()
+    method = _method("delivery")
+    order_id = "order-1"
+    body = json.dumps({"id": order_id}).encode()
+
+    post_mock = MagicMock()
+    monkeypatch.setattr("app.requests.post", post_mock)
+
+    app.on_message(channel, method, None, body)
+
+    post_mock.assert_called_once_with(f"{app.ORDER_URL}/orders/{order_id}/confirm")
+    channel.basic_ack.assert_called_once_with(delivery_tag="delivery")
+
+
+def test_on_message_acknowledges_when_order_id_is_missing(monkeypatch):
+    channel = MagicMock()
+    method = _method("tag")
+    body = b"{}"
+
+    post_mock = MagicMock()
+    monkeypatch.setattr("app.requests.post", post_mock)
+
+    app.on_message(channel, method, None, body)
+
+    post_mock.assert_not_called()
+    channel.basic_ack.assert_called_once_with(delivery_tag="tag")

--- a/tests/bdd/package-lock.json
+++ b/tests/bdd/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@cucumber/cucumber": "^9.0.0",
         "@types/amqplib": "^0.10.1",
+        "@types/node": "^24.0.0",
         "amqplib": "^0.10.3",
         "axios": "^1.5.0",
         "ts-node": "^10.9.1",

--- a/tests/bdd/package.json
+++ b/tests/bdd/package.json
@@ -2,6 +2,7 @@
   "name": "bdd-tests",
   "version": "1.0.0",
   "scripts": {
+    "lint": "tsc --noEmit --skipLibCheck",
     "test": "cucumber-js --require-module ts-node/register --require features/steps/**/*.ts features/**/*.feature"
   },
   "devDependencies": {
@@ -10,6 +11,7 @@
     "typescript": "^5.2.2",
     "axios": "^1.5.0",
     "amqplib": "^0.10.3",
-    "@types/amqplib": "^0.10.1"
+    "@types/amqplib": "^0.10.1",
+    "@types/node": "^24.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Spotless, lint/test/security targets, and shared tooling scripts so each module can be validated consistently
- create unit tests for the order-service application layers and the Python scheduler agent, plus TypeScript lint coverage for the BDD suite
- configure a CI workflow that runs linting, testing, and security checks across services

## Testing
- `make lint`
- `make test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917441f8754832e86b095d0ece1c3d9)