### PR TITLE
docs: align Microservice Shop with its real architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,138 @@
 # Microservice Shop
 
-Microservice Shop é uma plataforma de pedidos pensada para demonstrar padrões de mensageria e automação com serviços independentes. O monorepo inclui um serviço Java para gerenciamento de pedidos, um worker Python que confirma pedidos de forma assíncrona, além de testes BDD em TypeScript. A stack padrão utiliza Docker Compose para expor HTTP, AMQP e ferramentas de observabilidade prontas para laboratório.
+**Microservice Shop** é uma plataforma de processamento de pedidos orientada a eventos, construída para explorar problemas reais de sistemas distribuídos em uma stack poliglota Java/Python.
 
-## Visão geral
-- **Orquestração**: `docker-compose.yml` provisiona RabbitMQ, `order-service` (Spring Boot) e `scheduler-agent` (Python).
-- **Fluxo de pedidos**: clientes criam pedidos via `POST /orders`. O serviço publica um evento `order.created` no RabbitMQ, consumido pelo scheduler para confirmar o pedido.
-- **Testes end-to-end**: `tests/bdd` contém cenários Cucumber simulando a criação de pedidos e verificando mensagens.
+O fluxo principal combina uma API Spring Boot, RabbitMQ e um worker Python para processar pedidos de forma assíncrona. A evolução arquitetural do projeto está concentrada em confiabilidade: consistência entre estado e evento, processamento idempotente, recuperação de falhas, contratos versionados e observabilidade.
 
-## Destaques de IA/LLM
-Mesmo que os serviços de produção sejam tradicionais, o repositório mantém trilhas de experimentação com IA e LLMs:
-- **Notebooks de experimentos** documentados em [`docs/experiments-notebooks.md`](docs/experiments-notebooks.md) descrevem como usar embeddings e LLMs para analisar dados de pedidos e gerar respostas automatizadas.
-- **Roadmap** inclui iniciativas de copiloto operacional e de previsão baseada em modelos generativos para o pipeline de pedidos. Veja [`ROADMAP.md`](ROADMAP.md).
-- **Guides de integração** recomendam como transformar os experimentos em features observáveis, preservando limites claros entre microsserviços e camadas de IA.
+## Estado atual
 
-## Como usar
-### Pré-requisitos
-- Docker e Docker Compose (v2+).
-- Acesso a portas `8080`, `5672` e `15672`.
-- Opcional para desenvolvimento local sem containers: Java 17, Maven 3.9+, Python 3.11 e Node 18.
+Hoje o repositório implementa:
 
-### Subindo toda a stack
-```bash
-docker compose up -d
+- `order-service` em Java 17 + Spring Boot;
+- criação e confirmação de pedidos via HTTP;
+- publicação do evento `order.created` em RabbitMQ;
+- `scheduler-agent` em Python consumindo eventos e acionando a confirmação;
+- Docker Compose para executar a stack local;
+- testes unitários em Java e Python;
+- suíte BDD em TypeScript/Cucumber;
+- ADRs e documentação arquitetural;
+- experimentos executáveis de ML clássico para previsão de demanda e detecção de anomalias.
+
+O repositório **ainda não possui** persistência PostgreSQL, Transactional Outbox, retry/DLQ completos, observabilidade distribuída ou uma feature LLM integrada. Esses itens aparecem apenas quando fazem parte do plano de evolução e não são apresentados como capacidades concluídas.
+
+## Arquitetura atual
+
+```mermaid
+flowchart LR
+    C[Client] -->|POST /orders| API[order-service\nJava + Spring Boot]
+    API -->|save| MEM[(In-memory repository)]
+    API -->|order.created| MQ{{RabbitMQ}}
+    MQ --> W[scheduler-agent\nPython]
+    W -->|POST /orders/{id}/confirm| API
 ```
-1. Aguarde o healthcheck de RabbitMQ (`http://localhost:15672`).
-2. Verifique o serviço de pedidos: `curl http://localhost:8080/actuator/health`.
-3. Monitore os logs do scheduler: `docker compose logs -f scheduler-agent`.
 
-### Criando e confirmando pedidos
+### Stack
+
+| Área | Tecnologia |
+|---|---|
+| API | Java 17, Spring Boot, Spring AMQP |
+| Worker | Python 3.11, pika, requests |
+| Mensageria | RabbitMQ |
+| Testes E2E | TypeScript, Cucumber, Axios, amqplib |
+| Execução local | Docker Compose |
+| ML experimental | Python, pandas, scikit-learn |
+| Automação | Makefile, GitHub Actions |
+
+## Por que este projeto existe
+
+O projeto não tenta maximizar a quantidade de serviços. O objetivo é aprofundar um fluxo distribuído pequeno o suficiente para ser compreendido por inteiro e complexo o suficiente para discutir propriedades que importam em produção:
+
+- o que acontece quando uma chamada HTTP falha depois de uma mensagem ser entregue;
+- como evitar perda silenciosa de eventos;
+- como lidar com reentrega e efeitos duplicados;
+- como garantir consistência entre persistência e publicação;
+- como observar um pedido atravessando processos diferentes;
+- como provar essas propriedades com testes automatizados.
+
+## Evolução arquitetural
+
+O alvo aprovado para a próxima versão é:
+
+```text
+Client
+  -> order-service
+      -> PostgreSQL
+      -> Transactional Outbox
+          -> RabbitMQ
+              -> scheduler-agent
+                  -> retry / DLQ
+                  -> confirmação idempotente
+```
+
+A estratégia completa, incluindo matriz de gaps, arquitetura-alvo, ondas de implementação e Definition of Done, está em [`docs/05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md`](docs/05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md).
+
+A auditoria factual que motivou esse plano está em [`docs/05-evolucao/AUDITORIA_ESTADO_ATUAL.md`](docs/05-evolucao/AUDITORIA_ESTADO_ATUAL.md).
+
+## Executando localmente
+
+### Pré-requisitos
+
+- Docker;
+- Docker Compose v2+.
+
+### Subir a stack
+
 ```bash
-# Cria um pedido
+docker compose up -d --build
+```
+
+Serviços principais:
+
+- API: `http://localhost:8080`;
+- health: `http://localhost:8080/actuator/health`;
+- RabbitMQ Management: `http://localhost:15672`.
+
+### Criar um pedido
+
+```bash
 curl -X POST http://localhost:8080/orders \
   -H "Content-Type: application/json" \
   -d '{"productId":"SKU-1","quantity":2}'
-
-# Após o evento ser consumido, o scheduler chama automaticamente
-# POST /orders/{id}/confirm. Use os logs do order-service
-# para verificar a transição de status.
 ```
 
-### Executando testes
-- `make api-test` roda `mvn test` em `services/api/order-service` (ainda sem casos, configure ao evoluir).
-- `make bdd-test` instala dependências e executa `npm test` em `tests/bdd` (exige stack rodando).
-- Consulte [`docs/runbook.md`](docs/runbook.md) para tarefas adicionais com o `Makefile`.
+O pedido é criado como `PENDING`, um evento é publicado no RabbitMQ e o worker tenta confirmar o pedido de forma assíncrona.
+
+## Qualidade e testes
+
+O `Makefile` centraliza as rotinas principais:
+
+```bash
+make lint
+make test
+make security
+make bdd-test
+```
+
+Os testes Java e Python já existem no estado atual. A suíte BDD também existe, mas sua execução como gate distribuído completo faz parte da evolução planejada porque o desenho atual ainda possui competição pela fila do consumidor.
+
+## ML e IA
+
+O repositório possui duas trilhas de ML clássico executáveis:
+
+- `ml/experiments/demand-forecasting`;
+- `ml/experiments/order-anomaly-detection`.
+
+A área `ml/llm` é experimental e ainda não representa uma feature LLM integrada ao produto. A decisão atual é não adicionar um `AI Advisor` ou outro microsserviço de IA antes de existir um caso de uso implementado e justificável.
 
 ## Documentação
-- [`docs/setup.md`](docs/setup.md): dependências, variáveis e procedimentos de instalação.
-- [`docs/runbook.md`](docs/runbook.md): runbooks, troubleshooting e validações.
-- [`docs/architecture.md`](docs/architecture.md): visão sistêmica, diagramas e contratos.
-- [`docs/experiments-notebooks.md`](docs/experiments-notebooks.md): governança dos experimentos de IA/LLM.
-- [`docs/restructure-plan.md`](docs/restructure-plan.md): inventário histórico do repositório.
-- [`docs/entregas-estagio.md`](docs/entregas-estagio.md): destaque das entregas do estágio, seus impactos e relação com requisitos de LLMs, MLOps e documentação.
-- [`docs/proximos-passos.md`](docs/proximos-passos.md): guia consolidado do que falta para considerar o projeto pronto para demos ou piloto.
 
-## Estrutura do repositório
-```
-microservice-shop/
-├── docker-compose.yml          # Orquestra RabbitMQ + serviços
-├── services/
-│   ├── api/order-service/      # API Java 17 + Spring Boot
-│   └── workers/scheduler-agent/ # Worker Python que consome RabbitMQ
-├── ml/llm/                     # Notebooks e libs de experimentação IA/LLM
-├── infra/terraform/            # Ponto de partida para provisionamento IaC
-├── tests/
-│   └── bdd/                    # Cenários Cucumber em TypeScript
-└── docs/                       # Guias, arquitetura e experimentos
-```
+As fontes principais são:
 
-### Scripts padronizados
-Um `Makefile` centraliza as rotinas mais comuns:
+- [`docs/00-produto/`](docs/00-produto/) — visão e escopo;
+- [`docs/02-arquitetura/visao-tecnica.md`](docs/02-arquitetura/visao-tecnica.md) — arquitetura atualmente implementada;
+- [`docs/02-arquitetura/decisoes/`](docs/02-arquitetura/decisoes/) — ADRs;
+- [`docs/04-operacao/`](docs/04-operacao/) — operação;
+- [`docs/05-evolucao/`](docs/05-evolucao/) — auditoria e plano arquitetural vigente;
+- [`ROADMAP.md`](ROADMAP.md) — sequência de evolução.
 
-| Comando | Descrição |
-| --- | --- |
-| `make compose-up` / `make compose-down` | Sobe/derruba a stack completa com Docker Compose. |
-| `make api-test` | Executa `mvn test` no `services/api/order-service`. |
-| `make worker-run` | Exporta variáveis (`RABBIT_URL`, `ORDER_URL`) e sobe o worker Python localmente. |
-| `make bdd-test` | Instala dependências e executa os testes BDD. |
-| `make llm-setup` | Instala as dependências listadas em `ml/llm/requirements.txt`. |
-
-Use `make help` para visualizar todas as metas disponíveis e parâmetros adicionais.
-
-## Próximos passos
-Consulte [`ROADMAP.md`](ROADMAP.md), [`CHANGELOG.md`](CHANGELOG.md) e o guia de [próximos passos](docs/proximos-passos.md) para entender prioridades, evolução e o que falta para finalizar o projeto. Contribuições são bem-vindas via PR seguindo as orientações do arquivo `AGENTS.md` na raiz.
+Documentos históricos continuam no repositório quando úteis para rastreabilidade, mas não devem ser tratados como fonte canônica do estado atual.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,25 +1,101 @@
-# Roadmap
+# Roadmap — Microservice Shop
 
-Visão macro das próximas entregas para o Microservice Shop. As datas são estimativas e podem mudar conforme descobertas.
+Este roadmap descreve a sequência de evolução do projeto. Ele não usa datas artificiais: cada etapa só avança quando os critérios técnicos da etapa anterior estão satisfeitos.
 
-## Q2 2024 – Fundamentos
-1. **Cobertura de testes mínima** no `order-service` (unitários + integração AMQP).
-2. **Refinamento do scheduler**: substituir lógica síncrona por confirmações idempotentes e adicionar telemetria básica.
-3. **Infra de dados para IA**: padronizar export de eventos e pipelines de dados compartilhados com notebooks (`data/`).
+## Onda 0 — Verdade do projeto
 
-## Q3 2024 – Novos serviços e IA aplicada
-1. **Catalog-service** (Node/TypeScript) expondo `GET /products` e cache em Redis.
-2. **Auth-service** (ASP.NET Core) fornecendo JWT para proteger `order-service`.
-3. **AI Advisor**: microsserviço dedicado a recomendações, alimentado pelos notebooks de LLM; inicialmente expõe `POST /advice/orders` retornando explicações textuais.
+Objetivo: alinhar documentação, arquitetura descrita e capacidades reais.
 
-## Q4 2024 – Observabilidade e automação
-1. **Tracing distribuído** com OpenTelemetry em todos os serviços.
-2. **Playbooks gerados por LLM** integrados ao scheduler (sugestões de recuperação diretamente nos logs).
-3. **Pipeline CI/CD** executando notebooks críticos em modo headless para garantir reprodutibilidade.
+- [x] auditar o estado atual;
+- [x] definir arquitetura-alvo;
+- [ ] reposicionar README e visão de produto;
+- [ ] eliminar contradições entre documentação e código;
+- [ ] marcar documentos históricos como não canônicos;
+- [ ] consolidar fontes de arquitetura e evolução.
 
-## Backlog estratégico
-- Persistência real (PostgreSQL) para pedidos e histórico de eventos.
-- Suporte a múltiplas filas (dead-letter, retries) com políticas configuráveis.
-- Dashboards que combinam métricas tradicionais e insights dos modelos generativos.
+**Saída:** qualquer pessoa deve conseguir distinguir claramente o que está implementado, o que está planejado e o que é histórico.
 
-Acompanhe mudanças confirmadas no [`CHANGELOG.md`](CHANGELOG.md) e utilize issues/PRs para propor replanejamentos.
+## Onda 1 — Confiabilidade e consistência
+
+Objetivo: transformar o fluxo de pedidos em um fluxo distribuído tecnicamente consistente.
+
+- [ ] introduzir PostgreSQL como persistência do `order-service`;
+- [ ] versionar migrações;
+- [ ] modelar `OrderStatus` e invariantes de domínio;
+- [ ] adicionar `GET /orders/{id}`;
+- [ ] implementar Transactional Outbox;
+- [ ] criar publisher de eventos pendentes;
+- [ ] versionar `order.created.v1` com identidade e correlação;
+- [ ] separar nomes de evento das filas de consumidores;
+- [ ] corrigir ACK do worker;
+- [ ] implementar timeout HTTP;
+- [ ] implementar retry com atraso;
+- [ ] implementar Dead Letter Queue;
+- [ ] tornar confirmação repetida idempotente.
+
+**Saída:** persistir pedido e registrar evento na mesma transação; processamento assíncrono tolerante a reentrega e falhas transitórias.
+
+## Onda 2 — Provas automatizadas
+
+Objetivo: provar as propriedades arquiteturais no CI.
+
+- [ ] ampliar testes unitários de domínio e políticas de retry;
+- [ ] adicionar testes de integração com PostgreSQL;
+- [ ] adicionar testes de integração com RabbitMQ;
+- [ ] validar Outbox e publicação;
+- [ ] criar fila exclusiva de auditoria para BDD;
+- [ ] provar `POST /orders -> evento -> worker -> CONFIRMED`;
+- [ ] usar `npm ci` no CI;
+- [ ] executar auditoria real das dependências usadas;
+- [ ] separar pipeline em quality, unit-tests, security e integration-e2e;
+- [ ] publicar logs dos containers como artifact em falhas E2E.
+
+**Saída:** uma PR não fica verde se o ciclo distribuído real estiver quebrado.
+
+## Onda 3 — Observabilidade
+
+Objetivo: tornar o fluxo assíncrono rastreável sem tornar o ambiente local pesado.
+
+- [ ] logs JSON estruturados;
+- [ ] `correlationId`, `eventId` e `orderId` ponta a ponta;
+- [ ] métricas de pedidos, Outbox, retries e DLQ;
+- [ ] instrumentação OpenTelemetry;
+- [ ] profile opcional de observabilidade no Compose;
+- [ ] documentação de troubleshooting orientada a sinais.
+
+**Saída:** um pedido pode ser rastreado entre API, banco, broker e worker.
+
+## Onda 4 — Diferenciação
+
+Somente após o core distribuído estar estável, escolher **uma** frente principal de diferenciação.
+
+### Opção A — Cloud/IaC real
+
+- IaC executável para uma arquitetura coerente;
+- pipeline de build/deploy;
+- smoke tests e estratégia de rollback.
+
+### Opção B — ML integrado
+
+- selecionar um dos experimentos atuais;
+- definir contrato de entrada/saída;
+- integrar ao fluxo sem bloquear o processamento principal;
+- medir qualidade e comportamento operacional.
+
+A decisão entre A e B deve ser registrada por ADR. Não implementar as duas frentes simultaneamente sem justificativa.
+
+## Fora do roadmap imediato
+
+Não fazem parte das ondas atuais:
+
+- `catalog-service` apenas para aumentar o número de serviços;
+- `auth-service` separado sem necessidade de produto;
+- `payment-service`;
+- frontend;
+- Kubernetes;
+- múltiplas clouds;
+- `AI Advisor`/LLM sem feature real implementada.
+
+## Referência arquitetural
+
+A motivação e os critérios completos estão em [`docs/05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md`](docs/05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md).

--- a/docs/00-produto/mvp-e-escopo.md
+++ b/docs/00-produto/mvp-e-escopo.md
@@ -1,30 +1,82 @@
-# MVP e Escopo — microservice-shop
+# Escopo Atual — Microservice Shop
 
-## O que está implementado
+Este documento separa **implementado**, **em evolução** e **fora do núcleo atual**. Ele não deve antecipar capacidades ainda inexistentes.
 
-| Componente | Status |
-|-----------|--------|
-| order-service (Spring Boot): POST /orders + POST /orders/{id}/confirm | ✅ |
-| Publicação de evento `order.created` no RabbitMQ | ✅ |
-| scheduler-agent (Python): consumidor AMQP + chamada de confirmação | ✅ |
-| Testes BDD Cucumber (TypeScript) | ✅ |
-| Docker Compose com RabbitMQ, order-service e scheduler-agent | ✅ |
-| Makefile com comandos padronizados | ✅ |
-| Experimentos ML: previsão de demanda + detecção de anomalias | ✅ (dados de exemplo) |
-| Documentação de arquitetura (Mermaid + contratos) | ✅ |
-| GitHub Actions CI | ✅ |
+## Implementado
 
-## O que está FORA do MVP atual
+| Capacidade | Estado |
+|---|---|
+| `order-service` em Java 17 + Spring Boot | ✅ |
+| `POST /orders` | ✅ |
+| `POST /orders/{id}/confirm` | ✅ |
+| repositório em memória para pedidos | ✅ |
+| publicação de `order.created` no RabbitMQ | ✅ |
+| `scheduler-agent` Python consumindo AMQP | ✅ |
+| chamada assíncrona do worker para confirmação | ✅ |
+| Docker Compose com RabbitMQ + serviços | ✅ |
+| testes unitários Java | ✅ |
+| testes unitários Python | ✅ |
+| BDD em TypeScript/Cucumber | ✅ |
+| GitHub Actions para lint/test/security | ✅ |
+| ADRs arquiteturais | ✅ |
+| previsão de demanda experimental | ✅ |
+| detecção de anomalias experimental | ✅ |
 
-- [ ] Banco de dados real (order-service usa in-memory)
-- [ ] Autenticação/autorização
-- [ ] Frontend
-- [ ] catalog-service, auth-service (planejados no roadmap)
-- [ ] Retry logic com dead letter queue (DLQ)
-- [ ] Deploy em cloud
+## Limitações conhecidas do estado atual
 
-## Roadmap pós-MVP
+- persistência é in-memory;
+- salvar pedido e publicar evento são operações separadas;
+- o worker confirma mensagens mesmo quando a chamada HTTP pode falhar;
+- não há política completa de retry/DLQ;
+- o contrato do evento não possui envelope/versionamento suficiente;
+- não existe `GET /orders/{id}`;
+- a suíte BDD atual não prova o ciclo assíncrono completo de forma isolada;
+- o CI não sobe a stack distribuída como gate obrigatório;
+- observabilidade se limita a health/logs básicos;
+- a área LLM ainda não possui feature implementada;
+- Terraform existente é apenas espaço/documentação, não infraestrutura executável.
 
-- **v1.1:** Persistência real (PostgreSQL) no order-service
-- **v1.2:** catalog-service + auth-service
-- **v2.0:** Integração LLM no pipeline (copiloto operacional + previsão)
+Esses pontos são detalhados em [`../05-evolucao/AUDITORIA_ESTADO_ATUAL.md`](../05-evolucao/AUDITORIA_ESTADO_ATUAL.md).
+
+## Em evolução aprovada
+
+A próxima evolução do núcleo inclui:
+
+- PostgreSQL;
+- migrações versionadas;
+- domínio com invariantes e `OrderStatus`;
+- `GET /orders/{id}`;
+- Transactional Outbox;
+- evento `order.created.v1` versionado;
+- filas específicas por consumidor;
+- timeout, ACK correto, retry e DLQ;
+- confirmação idempotente;
+- integração/E2E no CI;
+- logs correlacionados e, posteriormente, métricas/tracing.
+
+A ordem está em [`../../ROADMAP.md`](../../ROADMAP.md).
+
+## Fora do núcleo atual
+
+Não fazem parte do escopo imediato:
+
+- frontend;
+- `catalog-service`;
+- `auth-service` dedicado;
+- `payment-service`;
+- Kubernetes;
+- múltiplas clouds;
+- `AI Advisor`/serviço LLM.
+
+Esses itens só devem voltar ao planejamento se houver uma necessidade concreta que justifique uma nova fronteira ou uma nova capacidade de produto.
+
+## Critério de entrada no escopo
+
+Uma nova feature ou serviço deve responder positivamente a pelo menos uma destas perguntas:
+
+1. resolve um problema real do fluxo de pedidos?
+2. aumenta uma propriedade arquitetural que podemos testar?
+3. permite demonstrar uma decisão de engenharia com trade-offs claros?
+4. pode ser executado e validado de forma reproduzível?
+
+Se a única justificativa for “adicionar mais uma tecnologia ao projeto”, o item permanece fora do núcleo.

--- a/docs/00-produto/visao-e-objetivo.md
+++ b/docs/00-produto/visao-e-objetivo.md
@@ -1,19 +1,79 @@
-# Visão e Objetivo — microservice-shop
+# Visão e Objetivo — Microservice Shop
 
-## Problema que resolve
+## Problema
 
-Desenvolvedores que querem demonstrar arquitetura de microsserviços precisam de um projeto de referência que integre múltiplas linguagens, mensageria assíncrona e IA/ML num único repositório coeso. Projetos de estudo típicos cobrem só uma stack.
+Processamento assíncrono de pedidos parece simples enquanto todos os componentes estão disponíveis. O problema real aparece quando banco, broker, rede ou consumidor falham em momentos diferentes: eventos podem se perder, mensagens podem ser entregues novamente, efeitos podem ser duplicados e o estado final pode se tornar difícil de rastrear.
 
-## Solução proposta
+## Solução
 
-Monorepo com serviços independentes em Java e Python comunicando-se via RabbitMQ, testes BDD ponta-a-ponta, e uma trilha de experimentação com IA/LLM que mostra como a inteligência pode ser adicionada ao pipeline de pedidos sem quebrar a separação de serviços.
+O Microservice Shop modela um fluxo de pedidos orientado a eventos em uma stack poliglota e mantém o escopo deliberadamente pequeno para tornar as propriedades distribuídas observáveis e testáveis de ponta a ponta.
 
-## Objetivo
+O sistema combina:
 
-- **Principal:** Portfólio que demonstra microsserviços, mensageria AMQP, BDD e integração de IA
-- **Secundário:** Trilha de aprendizado para MLOps/LLMOps num contexto de e-commerce
-- **O que não é objetivo:** Sistema de pedidos para produção; e-commerce completo
+- API de pedidos em Java/Spring Boot;
+- mensageria RabbitMQ;
+- worker assíncrono em Python;
+- execução local com Docker Compose;
+- testes Java, Python e BDD;
+- documentação de decisões arquiteturais;
+- uma trilha experimental separada de ML.
 
-## Posicionamento em uma frase
+## Objetivo principal
 
-> Para desenvolvedores que precisam demonstrar arquitetura distribuída e integração de IA, o microservice-shop é um monorepo de referência que mostra microsserviços em Java e Python se comunicando via RabbitMQ com trilhas de ML/LLM prontas para evoluir.
+Construir um fluxo de processamento de pedidos que possa demonstrar, por implementação e testes, propriedades como:
+
+- consistência entre estado persistido e evento;
+- entrega at-least-once;
+- idempotência;
+- retry e Dead Letter Queue;
+- contratos de evento versionados;
+- rastreabilidade entre processos;
+- recuperação de falhas transitórias;
+- CI capaz de provar o ciclo distribuído completo.
+
+## Princípio de escopo
+
+**Profundidade antes de quantidade.**
+
+O projeto não adiciona um novo microsserviço apenas para aumentar o diagrama. Uma nova fronteira distribuída só entra quando possui uma responsabilidade própria e aumenta a qualidade da tese arquitetural.
+
+Por isso, catálogo, autenticação separada, pagamentos, frontend, Kubernetes e um serviço LLM não fazem parte do núcleo atual.
+
+## Estado atual e estado-alvo
+
+### Atual
+
+```text
+Client
+  -> order-service
+      -> in-memory repository
+      -> RabbitMQ
+          -> scheduler-agent
+              -> order-service /confirm
+```
+
+### Evolução aprovada
+
+```text
+Client
+  -> order-service
+      -> PostgreSQL + Transactional Outbox
+          -> RabbitMQ
+              -> scheduler-agent
+                  -> retry / DLQ
+                  -> confirmação idempotente
+```
+
+A evolução completa está documentada em [`../05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md`](../05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md).
+
+## O que o projeto não afirma
+
+No estado atual, o projeto não se apresenta como:
+
+- e-commerce completo;
+- solução pronta para produção;
+- arquitetura cloud já provisionada;
+- plataforma de LLM;
+- sistema com exactly-once delivery.
+
+O objetivo é ser tecnicamente preciso: cada capacidade pública deve ser sustentada por código, configuração ou teste reproduzível.

--- a/docs/02-arquitetura/visao-tecnica.md
+++ b/docs/02-arquitetura/visao-tecnica.md
@@ -1,80 +1,126 @@
-# Visão Técnica — microservice-shop
+# Visão Técnica — Microservice Shop
 
-## Stack por serviço
+> **Escopo deste documento:** arquitetura atualmente implementada. A evolução futura está em [`../05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md`](../05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md).
 
-| Serviço | Linguagem | Framework | Comunicação |
-|---------|-----------|-----------|-------------|
-| order-service | Java 17 | Spring Boot 3 + Spring AMQP | HTTP (entrada) + AMQP (saída) |
-| scheduler-agent | Python 3.11 | pika (AMQP) + requests (HTTP) | AMQP (entrada) + HTTP (saída) |
-| tests/bdd | TypeScript | Cucumber + axios | HTTP + AMQP |
-| ml/experiments | Python | scikit-learn | — (notebooks/scripts standalone) |
-| ml/llm | Python | LangChain / OpenAI | — (notebooks standalone) |
+## Stack atual
 
-## Estrutura do repositório
+| Componente | Linguagem | Framework / libs | Comunicação |
+|---|---|---|---|
+| `order-service` | Java 17 | Spring Boot 3, Spring AMQP | HTTP + AMQP |
+| `scheduler-agent` | Python 3.11 | pika, requests | AMQP + HTTP |
+| `tests/bdd` | TypeScript | Cucumber, Axios, amqplib | HTTP + AMQP |
+| `ml/experiments` | Python | pandas, scikit-learn | scripts standalone |
+| RabbitMQ | — | RabbitMQ | AMQP |
 
-```
+A área `ml/llm` contém dependências e documentação experimental, mas não possui atualmente uma feature LLM integrada ao sistema.
+
+## Estrutura principal
+
+```text
 microservice-shop/
-├── docker-compose.yml
-├── Makefile
 ├── services/
-│   ├── api/order-service/          # Java Spring Boot
-│   │   ├── src/main/java/com/shop/order/
-│   │   │   ├── OrderApplication.java
-│   │   │   ├── application/         # Use cases
-│   │   │   ├── domain/              # Entidades
-│   │   │   ├── infrastructure/      # Repositório, AMQP, config
-│   │   │   └── interfaces/          # Controller HTTP
-│   │   └── pom.xml
-│   └── workers/scheduler-agent/     # Python worker
-│       └── app.py
-├── ml/
-│   ├── experiments/
-│   │   ├── demand-forecasting/      # Previsão de demanda
-│   │   └── order-anomaly-detection/ # Detecção de anomalias
-│   └── llm/                         # Experimentos LLM
-├── tests/
-│   └── bdd/                         # Cucumber TypeScript
-├── infra/terraform/                 # IaC (stub)
-└── docs/
+│   ├── api/order-service/
+│   │   └── src/main/java/com/shop/order/
+│   │       ├── domain/
+│   │       ├── application/
+│   │       ├── infrastructure/
+│   │       └── interfaces/
+│   └── workers/scheduler-agent/
+├── tests/bdd/
+├── ml/experiments/
+├── ml/llm/
+├── infra/terraform/
+├── docs/
+├── docker-compose.yml
+└── Makefile
 ```
 
-## Diagrama de arquitetura
+## Fluxo atual
 
-```
-[Cliente REST / BDD Tests]
-          │ HTTP POST /orders
-          ▼
-┌─────────────────────────┐
-│  order-service :8080    │
-│  (Java + Spring Boot)   │
-│  InMemoryOrderRepository│
-└────────────┬────────────┘
-             │ AMQP: order.exchange / order.created
-             ▼
-┌─────────────────────────┐
-│     RabbitMQ :5672      │
-│  (management :15672)    │
-└────────────┬────────────┘
-             │ consume: order.created
-             ▼
-┌─────────────────────────┐
-│  scheduler-agent :Python│
-│  → POST /orders/{id}/   │
-│       confirm           │
-└─────────────────────────┘
+```mermaid
+flowchart LR
+    Client[Cliente] -->|POST /orders| API[order-service]
+    API --> MEM[(InMemoryOrderRepository)]
+    API -->|order.created| EX{{order.exchange}}
+    EX --> Q[order.created]
+    Q --> W[scheduler-agent]
+    W -->|POST /orders/{id}/confirm| API
 ```
 
-## Padrão de arquitetura do order-service
+## Organização interna do `order-service`
 
-Clean Architecture em 4 camadas:
-- `domain/` — entidades puras (Order)
-- `application/` — use cases (CreateOrderService, ConfirmOrderService)
-- `infrastructure/` — repositório, publisher AMQP, configuração
-- `interfaces/` — controller HTTP (OrderController)
+A implementação está separada em quatro grupos:
 
-## Convenções de código
+- `domain/` — entidade `Order`;
+- `application/` — casos de uso de criação e confirmação;
+- `infrastructure/` — repositório, configuração AMQP e publisher;
+- `interfaces/` — controller HTTP.
 
-- Java: PascalCase para classes, camelCase para métodos/variáveis
-- Python: snake_case para variáveis e funções
-- Idioma do código: Inglês
-- Diagramas: Mermaid (inline no markdown, sem imagens binárias)
+Essa organização é **inspirada em Clean Architecture**, mas a implementação atual não é tratada como Clean Architecture estrita: `OrderRepository` ainda está em `infrastructure` e é importado pela camada de aplicação.
+
+A evolução prevista cria ports de saída em uma camada adequada e mantém adapters de persistência/mensageria em infraestrutura.
+
+## Contratos atuais
+
+### HTTP
+
+```text
+POST /orders
+POST /orders/{id}/confirm
+```
+
+### AMQP
+
+```text
+exchange: order.exchange
+routing key: order.created
+queue: order.created
+payload: id + productId + quantity + status
+```
+
+## Persistência
+
+A implementação atual usa `ConcurrentHashMap` através de `InMemoryOrderRepository`.
+
+Isso significa que:
+
+- pedidos não sobrevivem a restart;
+- não existe transação de banco;
+- persistência e publicação AMQP não são atômicas.
+
+## Testes atuais
+
+O repositório possui:
+
+- testes unitários de aplicação e controller Java;
+- testes unitários do worker Python;
+- cenários BDD em Cucumber.
+
+A suíte BDD atual observa a própria fila `order.created`, que também é consumida pelo scheduler. Por isso, o desenho atual não é adequado como prova distribuída determinística quando ambos estão ativos.
+
+## Infraestrutura
+
+- Docker Compose executa RabbitMQ, `order-service` e `scheduler-agent`;
+- `infra/terraform` é atualmente um placeholder documental, sem recursos Terraform implementados;
+- GitHub Actions executa lint, testes unitários e segurança, mas ainda não executa a stack distribuída completa como gate obrigatório.
+
+## Evolução aprovada
+
+O próximo estágio técnico adiciona:
+
+```text
+PostgreSQL
++ Transactional Outbox
++ order.created.v1
++ filas por consumidor
++ retry/DLQ
++ idempotência
++ E2E no CI
++ correlação/observabilidade
+```
+
+Para detalhes e trade-offs, consulte:
+
+- [`../05-evolucao/AUDITORIA_ESTADO_ATUAL.md`](../05-evolucao/AUDITORIA_ESTADO_ATUAL.md)
+- [`../05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md`](../05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md)
+- [`../../ROADMAP.md`](../../ROADMAP.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,44 +1,92 @@
-# Arquitetura
+# Arquitetura Atual — Microservice Shop
 
-Este documento descreve a arquitetura atual do Microservice Shop, cobrindo microsserviços, mensagens e contratos expostos.
+> Este documento descreve **somente o que está implementado hoje**. A arquitetura-alvo está em [`05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md`](05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md).
 
 ## Visão em alto nível
+
 ```mermaid
 flowchart LR
     Client((Cliente REST)) -->|POST /orders| OrderService
-    OrderService[order-service \n Spring Boot] -->|evento order.created| RabbitMQ[(RabbitMQ)]
-    RabbitMQ --> Scheduler[scheduler-agent \n Python Worker]
+    OrderService[order-service\nSpring Boot] -->|save| Repo[(InMemoryOrderRepository)]
+    OrderService -->|order.created| RabbitMQ[(RabbitMQ)]
+    RabbitMQ --> Scheduler[scheduler-agent\nPython]
     Scheduler -->|POST /orders/{id}/confirm| OrderService
 ```
 
-- **order-service** (`services/api/order-service`): API HTTP que cria pedidos, persiste em memória e publica eventos.
-- **RabbitMQ**: transporte AMQP usando exchange `order.exchange`, routing key `order.created` e fila homônima.
-- **scheduler-agent** (`services/workers/scheduler-agent`): worker que consome `order.created` e confirma pedidos.
+## Componentes
 
-## Componentes detalhados
-| Componente | Linguagem | Entradas | Saídas | Responsabilidade |
-| --- | --- | --- | --- | --- |
-| order-service (`services/api/order-service`) | Java 17 (Spring Boot) | HTTP (`POST /orders`, `POST /orders/{id}/confirm`), eventos `order.created`. | HTTP 201/200, eventos `order.created`. | Orquestra ciclo de vida do pedido e dispara mensagens para automação downstream. |
-| scheduler-agent (`services/workers/scheduler-agent`) | Python 3.11 | Fila `order.created` | HTTP `POST /orders/{id}/confirm` | Automatiza a confirmação assíncrona usando o ID publicado no evento. |
-| tests/bdd | Node 18 + Cucumber | HTTP/API, AMQP | Relatórios de testes | Valida cenários ponta-a-ponta usando RabbitMQ real. |
+| Componente | Tecnologia | Responsabilidade atual |
+|---|---|---|
+| `order-service` | Java 17 + Spring Boot | cria e confirma pedidos; publica `order.created` |
+| `InMemoryOrderRepository` | Java | mantém pedidos durante a vida do processo |
+| RabbitMQ | AMQP | transporta eventos entre produtor e consumidor |
+| `scheduler-agent` | Python 3.11 + pika + requests | consome evento e chama a confirmação HTTP |
+| `tests/bdd` | TypeScript + Cucumber | exercita API e RabbitMQ |
 
-## Contratos principais
-### HTTP – order-service
-| Método/rota | Payload | Resposta |
-| --- | --- | --- |
-| `POST /orders` | `{ "productId": string, "quantity": number }` | `201 Created` com `{ "id": string }`. Publica evento `order.created`. |
-| `POST /orders/{id}/confirm` | nenhum | `200 OK`. Atualiza estado do pedido. |
+## Contratos HTTP atuais
 
-### Mensageria
-| Exchange | Routing Key | Payload | Consumidor |
-| --- | --- | --- | --- |
-| `order.exchange` | `order.created` | `{ id, productId, quantity, status }` | `scheduler-agent` (fila `order.created`). |
+| Método | Rota | Comportamento |
+|---|---|---|
+| `POST` | `/orders` | cria um pedido e retorna `201` com `{ "id": string }` |
+| `POST` | `/orders/{id}/confirm` | marca o pedido como `CONFIRMED` e retorna `200` |
 
-## Dependências externas
-- **RabbitMQ**: obrigatório. Configure via `RABBIT_URL`.
-- **Banco de dados**: atualmente `InMemoryOrderRepository`. Planeje integração com PostgreSQL ou Mongo (ver `ROADMAP.md`).
+O estado atual ainda não expõe `GET /orders/{id}`.
 
-## Extensões planejadas
-- Adicionar `catalog-service`, `auth-service` e serviços de pagamento para refletir a visão completa descrita em [`docs/restructure-plan.md`](./restructure-plan.md).
-- Instrumentar métricas (Micrometer) e tracing distribuído.
-- Conectar notebooks LLM (`ml/llm/notebooks`) para prever demanda e sugerir promoções automatizadas (detalhes em [`docs/experiments-notebooks.md`](./experiments-notebooks.md)).
+## Contrato AMQP atual
+
+| Item | Valor |
+|---|---|
+| Exchange | `order.exchange` |
+| Routing key | `order.created` |
+| Fila | `order.created` |
+| Payload | `{ id, productId, quantity, status }` |
+
+Essa topologia funciona para o fluxo mínimo, mas conflui conceito de evento e fila do consumidor. A evolução aprovada separa esses papéis e introduz versionamento explícito.
+
+## Persistência atual
+
+O `order-service` usa `InMemoryOrderRepository`, baseado em `ConcurrentHashMap`.
+
+Consequências:
+
+- reiniciar o processo remove os pedidos;
+- não há transação de banco;
+- não é possível garantir atomicidade entre persistência e publicação;
+- o desenho atual é adequado apenas ao estágio presente do projeto.
+
+## Fronteiras arquiteturais
+
+O código está organizado em `domain`, `application`, `infrastructure` e `interfaces`, inspirado em Clean Architecture. Entretanto, o contrato `OrderRepository` ainda reside em `infrastructure` e é importado pelos casos de uso.
+
+Por isso, a documentação **não afirma que a implementação atual segue Clean Architecture estrita**. A evolução prevista move ports de saída para uma camada adequada e mantém adapters em infraestrutura.
+
+## Limitações distribuídas conhecidas
+
+As limitações mais importantes hoje são:
+
+- ACK do worker não depende de sucesso real da operação HTTP;
+- chamada HTTP sem timeout explícito;
+- ausência de retry/DLQ completos;
+- dual write entre persistência do pedido e publicação no broker;
+- confirmação não modelada como operação idempotente explícita;
+- evento sem envelope/versionamento/correlação suficientes;
+- BDD competindo pela fila do worker;
+- CI sem gate E2E distribuído.
+
+Esses pontos não são bugs escondidos da documentação: estão registrados formalmente na [`05-evolucao/AUDITORIA_ESTADO_ATUAL.md`](05-evolucao/AUDITORIA_ESTADO_ATUAL.md).
+
+## Arquitetura-alvo
+
+A evolução aprovada introduz:
+
+- PostgreSQL;
+- Transactional Outbox;
+- evento `order.created.v1`;
+- fila exclusiva do `scheduler-agent`;
+- retry com atraso e DLQ;
+- idempotência;
+- contratos versionados;
+- E2E distribuído no CI;
+- observabilidade correlacionada.
+
+O detalhamento e a sequência estão em [`05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md`](05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md) e no [`../ROADMAP.md`](../ROADMAP.md).

--- a/docs/entregas-estagio.md
+++ b/docs/entregas-estagio.md
@@ -1,30 +1,36 @@
-# Entregas do estágio: principais impactos e artefatos
+# Entregas do Estágio — Registro Histórico
 
-Esta visão resume as entregas consolidadas no Microservice Shop e como elas respondem aos requisitos do estágio focados em **LLMs**, **MLOps** e **documentação**. Use esta lista para reportar progresso e localizar rapidamente os materiais de apoio (vídeos, demos ou links externos quando existirem).
+> **Status:** histórico / não canônico.
+>
+> Este documento registra o contexto em que parte da documentação e das trilhas de IA/ML foi organizada originalmente. Ele não representa mais a narrativa principal, o backlog atual ou o estado técnico vigente do Microservice Shop.
 
-## Resumo das entregas
+## Por que este arquivo permanece
 
-| Entrega | Impacto principal | Artefatos disponíveis | Requisito do estágio |
-| --- | --- | --- | --- |
-| Trilhas de IA/LLM aplicadas ao fluxo de pedidos | Mantêm experimentos prontos para gerar copilotos e previsões a partir de dados reais de pedidos. | Documentação dedicada em [`docs/experiments-notebooks.md`](./experiments-notebooks.md) e bibliotecas em [`ml/llm/`](../ml/llm/). Sem vídeo/HuggingFace publicados ainda; notebooks podem ser executados localmente via `make llm-setup`. | **LLMs** |
-| Pipelines e governança MLOps/LLMOps | Padronizam ingestão, treino e deploy das trilhas de IA, garantindo versionamento e segurança para chaves LLM. | Guia completo em [`docs/mlops-llmops.md`](./mlops-llmops.md), além dos exemplos em [`ml/experiments/`](../ml/experiments/) e dos alvos do [`Makefile`](../Makefile). Demos adicionais podem ser reproduzidas com `docker compose up -d`. | **MLOps** |
-| Documentação operacional e runbooks unificados | Facilita onboarding, execução e troubleshooting da stack de microsserviços e dos experimentos de IA. | [`README.md`](../README.md), [`docs/setup.md`](./setup.md), [`docs/runbook.md`](./runbook.md) e [`docs/architecture.md`](./architecture.md). Ainda sem vídeo oficial; os exemplos de uso são executáveis localmente. | **Documentação** |
+O repositório preserva este material para rastreabilidade da evolução do projeto. Entretanto, superfícies públicas atuais devem usar como referência:
 
-## Detalhes por entrega
+- [`../README.md`](../README.md);
+- [`00-produto/visao-e-objetivo.md`](00-produto/visao-e-objetivo.md);
+- [`architecture.md`](architecture.md);
+- [`05-evolucao/AUDITORIA_ESTADO_ATUAL.md`](05-evolucao/AUDITORIA_ESTADO_ATUAL.md);
+- [`05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md`](05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md);
+- [`../ROADMAP.md`](../ROADMAP.md).
 
-### 1. Trilhas de IA/LLM aplicadas ao fluxo de pedidos
-- **Impacto:** garante que os times possam evoluir dos experimentos descritos em [`docs/experiments-notebooks.md`](./experiments-notebooks.md) para copilotos operacionais e previsões descritas no [`ROADMAP.md`](../ROADMAP.md).
-- **Artefatos:** notebooks, requisitos e utilitários residem em [`ml/llm/`](../ml/llm/) com instruções adicionais no [`ml/llm/README.md`](../ml/llm/README.md). Executar `make llm-setup` prepara o ambiente local; ainda não há publicação em HuggingFace ou vídeos demonstrativos.
-- **Conexão com o requisito:** cumpre o pilar de **LLMs** ao oferecer baseline de embeddings, previsão e geração de respostas para os dados de pedidos.
+## Contexto histórico resumido
 
-### 2. Pipelines e governança MLOps/LLMOps
-- **Impacto:** o guia [`docs/mlops-llmops.md`](./mlops-llmops.md) descreve como versionar datasets, armazenar segredos (Vault) e orquestrar deploys híbridos, reduzindo risco operacional.
-- **Artefatos:** exemplos práticos vivem em [`ml/experiments/demand-forecasting`](../ml/experiments/demand-forecasting/) e [`ml/experiments/order-anomaly-detection`](../ml/experiments/order-anomaly-detection/), enquanto os alvos `make llm-setup` e `make worker-run` demonstram pipelines locais. As demos podem ser reproduzidas com `docker compose up -d`; não há vídeo/hospedagem HuggingFace pública por enquanto.
-- **Conexão com o requisito:** cobre **MLOps**, pois detalha desde preparo de ambiente até execução controlada das trilhas LLM.
+Parte do trabalho anterior foi organizada em torno de três frentes:
 
-### 3. Documentação operacional e runbooks unificados
-- **Impacto:** os guias [`docs/setup.md`](./setup.md), [`docs/runbook.md`](./runbook.md) e [`docs/architecture.md`](./architecture.md) eliminam lacunas de execução, descrevendo dependências, fluxos AMQP e observabilidade. Isso acelera onboarding e reduz erros em produção.
-- **Artefatos:** o [`README.md`](../README.md) centraliza fluxos e comandos (incluindo `docker compose up -d` como demo local). Ainda não há vídeos oficiais, mas os comandos fornecem o passo a passo completo para reproduzir os cenários.
-- **Conexão com o requisito:** satisfaz **documentação**, pois consolida tutoriais, runbooks e arquitetura numa fonte única.
+- experimentação com IA/ML;
+- práticas de MLOps/LLMOps;
+- documentação e runbooks.
 
-> **Próximos passos:** ao publicar vídeos, demos hospedadas ou modelos em HuggingFace, atualize a coluna "Artefatos disponíveis" para manter o histórico completo das entregas.
+Essas frentes contribuíram com artefatos que ainda existem, especialmente os experimentos de ML em `ml/experiments` e a documentação operacional. Porém, a evolução atual do projeto está centrada em confiabilidade distribuída: consistência, Outbox, at-least-once, idempotência, retry/DLQ, contratos e observabilidade.
+
+## Estado atual da IA/ML
+
+- previsão de demanda: experimento executável;
+- detecção de anomalias: experimento executável;
+- LLM: sem feature integrada ao sistema no estado atual.
+
+Por isso, LLM/MLOps não devem ser usados para descrever o núcleo do projeto como se fossem capacidades de produção concluídas.
+
+O histórico detalhado das versões anteriores deste documento permanece acessível pelo Git.

--- a/docs/experiments-notebooks.md
+++ b/docs/experiments-notebooks.md
@@ -1,52 +1,84 @@
-# Guia de Notebooks e Experimentos de IA/LLM
+# Experimentos de ML e LLM
 
-Este guia organiza como conduzir experimentos de IA e modelos de linguagem em torno do Microservice Shop.
+Este documento descreve a trilha experimental separada do núcleo transacional do Microservice Shop.
 
-## Estrutura recomendada
-```
+## Estado real
+
+### Implementado
+
+O repositório possui dois experimentos de ML clássico com scripts executáveis de treino e inferência:
+
+- [`../ml/experiments/demand-forecasting`](../ml/experiments/demand-forecasting) — baseline de previsão de demanda;
+- [`../ml/experiments/order-anomaly-detection`](../ml/experiments/order-anomaly-detection) — baseline de detecção de anomalias.
+
+Os experimentos usam dados de exemplo e servem como baselines técnicos. Eles não são executados pelo fluxo principal de pedidos.
+
+### Ainda não implementado
+
+A área [`../ml/llm`](../ml/llm) possui dependências e estrutura para experimentação, mas `ml/llm/notebooks` não contém atualmente uma feature ou notebook LLM funcional versionado.
+
+Portanto, o projeto **não apresenta LLM como capacidade integrada** no estado atual.
+
+## Organização
+
+```text
 ml/
-├── llm/                 # Ambiente de notebooks ad-hoc
-│   ├── notebooks/
-│   └── requirements.txt
-└── experiments/
-    ├── demand-forecasting/
-    │   ├── data/
-    │   ├── notebooks/
-    │   ├── train.py / infer.py
-    │   └── README.md
-    └── order-anomaly-detection/
-        └── ...
+├── experiments/
+│   ├── demand-forecasting/
+│   │   ├── data/
+│   │   ├── train.py
+│   │   ├── infer.py
+│   │   └── README.md
+│   └── order-anomaly-detection/
+│       ├── data/
+│       ├── train.py
+│       ├── infer.py
+│       └── README.md
+└── llm/
+    ├── notebooks/
+    ├── requirements.txt
+    └── README.md
 ```
-- Notebooks exploratórios permanecem em `ml/llm/notebooks`.
-- Assim que um experimento amadurecer, mova notebooks limpos e scripts para `ml/experiments/<nome>/` e inclua um `README.md` com contexto, datasets e próximos passos.
-- Novos experimentos devem seguir o template de `ml/experiments/README.md`.
 
-## Fontes de dados
-1. **Eventos RabbitMQ**: utilize `docker compose logs order-service` ou conecte-se diretamente à fila `order.created` para exportar amostras.
-2. **APIs REST**: gere datasets via scripts que chamam `POST /orders` com dados sintéticos.
-3. **Arquivos locais**: armazene CSV/Parquet em `data/` (não versionado) e documente a origem.
+## Princípios
 
-## Fluxo sugerido para notebooks
-1. **Coleta & limpeza** – normalize colunas (`productId`, `quantity`, `status`, `timestamp`).
-2. **Feature engineering** – crie embeddings de descrições de produtos usando modelos como `text-embedding-3-large` (ou equivalentes self-hosted).
-3. **Modelagem** – explore duas frentes:
-   - *Forecasting/Anomalias*: modelos clássicos + prompts que consultam o histórico para justificar alertas.
-   - *Copiloto operacional*: LLM gera comandos `curl` ou consultas `kubectl` para operadores, usando contexto do runbook.
-4. **Avaliação** – capture métricas (MAE, precisão) e inclua checklist qualitativo dos prompts.
-5. **Produtização** – proponha rotas claras para mover o experimento para um serviço dedicado (por exemplo, `ai-advisor-service`).
+1. experimento deve ser reproduzível por script sempre que possível;
+2. dados sensíveis não entram no repositório;
+3. métricas devem acompanhar o artefato/modelo;
+4. experimento não é promovido a feature apenas porque funciona em notebook;
+5. integração ao sistema exige contrato, testes, observabilidade e justificativa arquitetural.
 
-## Integração com o monorepo
-- Armazene dependências em `ml/llm/requirements.txt` e utilize `pip install -r` dentro de um ambiente virtual.
-- Versione apenas notebooks limpos (`jupyter nbconvert --ClearOutputPreprocessor.enabled=True`).
-- Cada experimento deve conter scripts `train.py`/`infer.py` reproduzíveis e documentar o processo em seu README.
-- Referencie resultados relevantes em [`CHANGELOG.md`](../CHANGELOG.md) quando um experimento virar feature.
+## Demand forecasting
 
-## Boas práticas de prompt engineering
-- Documente cada prompt como código em células separadas.
-- Inclua testes unitários para helpers críticos (por exemplo, validação de esquema de resposta JSON).
-- Registre riscos de segurança (PII, vazamento de chaves) em cada notebook.
+O baseline atual usa regressão linear com features temporais e de cesta. A avaliação inclui MAE e R² em partição de teste.
 
-## Próximos experimentos
-- **Previsão de demanda**: treinar modelo híbrido (estatístico + LLM) para sugerir estoques – baseline disponível em `ml/experiments/demand-forecasting`.
-- **Detecção de fraude**: usar embeddings de histórico para detectar padrões anômalos antes da confirmação – baseada em `ml/experiments/order-anomaly-detection`.
-- **Geração de playbooks**: sintetizar runbooks específicos por incidente, alimentados pelo conteúdo de [`docs/runbook.md`](./runbook.md).
+Evoluções possíveis:
+
+- validação temporal em vez de split aleatório;
+- comparação com baselines sazonais;
+- tracking de experimentos;
+- integração somente se houver decisão explícita na Onda 4.
+
+## Order anomaly detection
+
+O baseline atual usa Isolation Forest sobre atributos tabulares de pedidos.
+
+A implementação deve continuar tratada como experimental: a avaliação atual ainda pode ser fortalecida com conjunto de validação independente, análise de recall/precision e limiar operacional.
+
+## LLM
+
+LLM permanece uma possibilidade futura, não uma obrigação arquitetural.
+
+Um caso de uso só deve ser implementado quando responder claramente:
+
+- qual decisão ou tarefa ele melhora;
+- por que um modelo tradicional/regra não basta;
+- quais dados/contexto são usados;
+- como a saída será avaliada;
+- como custo, latência, fallback e segurança serão tratados.
+
+Até lá, não há `AI Advisor` ou copiloto no roadmap imediato.
+
+## Relação com a evolução principal
+
+A confiabilidade distribuída do fluxo de pedidos tem prioridade sobre IA. Depois das Ondas 1–3, a Onda 4 pode escolher entre cloud/IaC real ou integração de um experimento de ML, conforme [`../ROADMAP.md`](../ROADMAP.md).

--- a/docs/proximos-passos.md
+++ b/docs/proximos-passos.md
@@ -1,40 +1,33 @@
-# Próximos passos para finalizar o projeto
+# Próximos Passos — Documento Substituído
 
-Este guia detalha o que falta para considerar o Microservice Shop "pronto" para demonstrações de alto impacto ou para um piloto controlado. As iniciativas abaixo complementam o roadmap e focam no hardening do que já existe antes de abrir novas frentes.
+> **Status:** histórico / não canônico.
+>
+> Este arquivo registrava um plano anterior de expansão do Microservice Shop. Ele foi substituído pela auditoria e pelo plano arquitetural aprovados em agosto de 2026.
 
-## 1. Concluir o escopo mínimo viável
-| Item | Objetivo | Responsável sugerido | Critérios de aceite |
-| --- | --- | --- | --- |
-| Cobertura de testes do `order-service` | Implementar unit tests para `OrderController`, `OrderService` e producers AMQP, além de um teste de integração usando Testcontainers. | Squad API | - `mvn test` com ≥70% de cobertura nas classes citadas.<br>- Build do CI verde com os novos testes. |
-| Refatorar o `scheduler-agent` | Garantir idempotência, logs estruturados e métricas básicas (tempo de confirmação, erros por minuto). | Squad Workers | - Retries configuráveis por variável de ambiente.<br>- Export de métricas no padrão Prometheus ou logs JSON com as mesmas informações. |
-| Testes BDD desacoplados de infraestrutura externa | Permitir que `npm test` rode em CI sem depender do RabbitMQ real, usando mocks ou containers efêmeros. | Chapter QA | - Pipeline CI consegue executar `make bdd-test` em < 5 min sem serviços extras.<br>- Documentação descreve as flags para rodar com stack real quando necessário. |
-| Limpeza de dependências versionadas | Remover `tests/bdd/node_modules` do controle de versão e reforçar `.gitignore`. | DevEx | - Repositório limpo após `git clean -fdx`.<br>- CI instala dependências sempre via `npm ci`. |
+## Fontes vigentes
 
-## 2. Expandir funcionalidades prometidas
-| Item | Objetivo | Dependências | Critérios de aceite |
-| --- | --- | --- | --- |
-| `catalog-service` | Expor `GET /products` com cache Redis e seed inicial. | Infra Redis via Compose. | - Endpoint documentado em OpenAPI.<br>- Testes unitários + integração com Redis (usando container). |
-| `auth-service` | Fornecer emissão e validação de JWT para proteger o `order-service`. | Integração com `order-service` e BDD. | - Middleware no `order-service` exigindo token.<br>- Cenário BDD cobrindo requisições autenticadas. |
-| `ai-advisor` | Consolidar notebooks em um microsserviço que gera recomendações textuais para pedidos. | Dados exportados do `order-service`. | - Endpoint `POST /advice/orders` com payload documentado.<br>- Testes de smoke + README com passos de reprodução do modelo. |
+Use estas referências para qualquer decisão atual:
 
-## 3. Preparar para operação contínua
-| Item | Objetivo | Entregáveis |
-| --- | --- | --- |
-| Observabilidade | Adotar OpenTelemetry nos serviços Java e Python, expondo traces e métricas padrão. | - Configuração `otel-collector` no Compose.<br>- Dashboards básicos (Grafana ou equivalente) documentados em `docs/runbook.md`. |
-| Automação de deploy | Expandir pipeline CI/CD para publicar imagens e executar smoke tests pós-deploy. | - Workflow GitHub Actions com stages `build`, `test`, `publish` e `smoke`.<br>- Checklist de rollback em `docs/runbook.md`. |
-| Governança de IA/LLM | Formalizar a passagem dos notebooks para produção (dados, versões de modelo, monitoramento). | - Processo descrito em `docs/mlops-llmops.md` com critérios de promoção.<br>- Scripts `ml/llm` versionados com tags de modelo. |
+1. [`05-evolucao/AUDITORIA_ESTADO_ATUAL.md`](05-evolucao/AUDITORIA_ESTADO_ATUAL.md) — diagnóstico factual da `main` antes da nova evolução;
+2. [`05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md`](05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md) — arquitetura-alvo, gaps e Definition of Done;
+3. [`../ROADMAP.md`](../ROADMAP.md) — ordem atual das ondas de implementação;
+4. [`architecture.md`](architecture.md) — arquitetura implementada no momento.
 
-## 4. Critérios de "pronto para demo/piloto"
-1. **Fluxo de pedidos coberto**: cenários de criação, confirmação automática e manual possuem testes unitários, integração e BDD verdes no CI.
-2. **Documentação alinhada**: README de cada serviço descreve autenticação, configurações e exemplos `curl`, e o novo escopo consta no `CHANGELOG.md`.
-3. **Observabilidade mínima**: logs estruturados + métricas básicas acessíveis via Docker Compose.
-4. **Segurança e dependências**: scanners de vulnerabilidade executam em cada pipeline e não há dependências instaladas manualmente no repositório.
-5. **IA integrada**: `ai-advisor` publicado com exemplo prático conectado ao fluxo de pedidos.
+## Por que este plano foi substituído
 
-## 5. Sequência sugerida
-1. **Hardening** (testes, scheduler, BDD sem acoplamento e limpeza de dependências).
-2. **Serviços adicionais** (catálogo, auth e advisor) em paralelo, priorizando integrações incrementais.
-3. **Observabilidade + CI/CD** para suportar as novas peças.
-4. **Go/No-Go review** usando os critérios acima antes de divulgar o projeto a recrutadores ou stakeholders.
+A estratégia anterior priorizava expansão de escopo com itens como `catalog-service`, `auth-service` e `ai-advisor` antes de resolver propriedades fundamentais do fluxo já existente.
 
-Mantenha este documento atualizado ao fechar cada item para que o status do projeto reflita a realidade durante entrevistas e apresentações.
+A auditoria posterior mostrou que o maior ganho técnico está em aprofundar o núcleo atual:
+
+- consistência entre pedido e evento;
+- Transactional Outbox;
+- entrega at-least-once;
+- idempotência;
+- retry/DLQ;
+- contratos versionados;
+- E2E distribuído no CI;
+- observabilidade correlacionada.
+
+## Valor histórico
+
+Este arquivo permanece versionado apenas para preservar a evolução das decisões do projeto. Ele **não deve ser usado como backlog vigente nem como descrição do estado atual**.

--- a/docs/restructure-plan.md
+++ b/docs/restructure-plan.md
@@ -1,45 +1,24 @@
-# Microservice Shop – Inventário e Plano de Reestruturação
+# Microservice Shop — Plano de Reestruturação Histórico
 
-## Mapa de Diretórios (profundidade 2)
-```
-microservice-shop/
-├── docker-compose.yml
-├── services/
-│   ├── api/
-│   │   └── order-service/
-│   └── workers/
-│       └── scheduler-agent/
-├── ml/
-│   └── llm/
-│       ├── notebooks/
-│       └── requirements.txt
-├── infra/
-│   └── terraform/
-└── tests/
-    └── bdd/
-```
-_Estrutura inspecionada a partir da raiz do repositório._
+> **Status:** histórico / não canônico.
+>
+> Este documento registra uma fotografia antiga do repositório e contém afirmações que já não representam o código atual, como ausência de testes Java/Python. Ele foi preservado apenas para rastreabilidade.
 
-## Estrutura-alvo padronizada
-| Pilar | Caminho | Observações |
-| --- | --- | --- |
-| APIs síncronas | `services/api/<serviço>` | Abriga microsserviços HTTP (ex.: `order-service`). |
-| Workers/eventos | `services/workers/<serviço>` | Processos orientados a filas, como `scheduler-agent`. |
-| IA/LLM | `ml/llm` | Centraliza notebooks, dependências e utilitários experimentais. |
-| Infraestrutura | `infra/terraform` | Repositório para módulos IaC futuros. |
+## Documento vigente
 
-O `Makefile` na raiz referencia esses caminhos para build/teste, garantindo nomenclatura consistente e scripts reutilizáveis.
+Para o estado atual e a próxima evolução, use:
 
-## Inventário dos Módulos
-| Módulo | Linguagem | Finalidade | Dependências principais | Status de testes |
-| --- | --- | --- | --- | --- |
-| `services/api/order-service` | Java 17 + Spring Boot | API REST para criar e confirmar pedidos, além de publicar eventos `order.created` no RabbitMQ. | `spring-boot-starter-web`, `spring-boot-starter-actuator`, `spring-boot-starter-amqp`, `jackson-databind`. | `mvn test` concluiu sem testes (`No tests to run`). |
-| `services/workers/scheduler-agent` | Python 3.11 | Worker que consome a fila `order.created` e chama `POST /orders/{id}/confirm` no serviço de pedidos. | `pika`, `requests`. | Não há testes automatizados definidos. |
-| `tests/bdd` | TypeScript + Cucumber.js | Suíte BDD cobrindo criação de pedidos e publicação de eventos. | `@cucumber/cucumber`, `ts-node`, `typescript`, `axios`, `amqplib`. | Não executado (exige RabbitMQ e order-service ativos). |
+- [`05-evolucao/AUDITORIA_ESTADO_ATUAL.md`](05-evolucao/AUDITORIA_ESTADO_ATUAL.md);
+- [`05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md`](05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md);
+- [`architecture.md`](architecture.md);
+- [`../ROADMAP.md`](../ROADMAP.md).
 
-## Problemas e Riscos Detectados
-1. **Serviços planejados ausentes** – Somente `order-service` e `scheduler-agent` existem no monorepo; `auth-service`, `catalog-service` e demais componentes citados na documentação não foram versionados.
-2. **Scheduler fora da stack planejada** – O worker foi implementado em Python em vez de C++ como definido no objetivo inicial, não havendo testes ou build que garantam seu comportamento.
-3. **Order-service sem cobertura automatizada** – A execução de `mvn test` finaliza sem qualquer caso, deixando lógicas críticas (validação, publicação em RabbitMQ) sem regressão.
-4. **BDD depende de infraestrutura externa** – A suíte usa axios/amqplib apontando para `localhost` sem mocks; não há scripts para subir dependências antes dos testes, dificultando sua execução em CI.
-5. **`node_modules` commitado em `tests/bdd`** – Dependências instaladas estão versionadas, o que aumenta o repositório e causa risco de divergência com `package-lock.json`.
+## Contexto histórico
+
+Este plano foi criado quando o projeto ainda estava consolidando sua estrutura de monorepo, testes e documentação. À época, foram identificadas lacunas como serviços ausentes, ausência de cobertura automatizada e BDD dependente da stack local.
+
+Desde então, parte dessas lacunas foi resolvida e outras foram reavaliadas. A estratégia atual não busca adicionar serviços apenas para ampliar o diagrama; prioriza confiabilidade do fluxo distribuído já existente.
+
+## Decisão de preservação
+
+O conteúdo detalhado anterior foi substituído por documentação canônica para evitar contradições públicas. O histórico permanece disponível no Git do repositório por meio das revisões anteriores deste arquivo.


### PR DESCRIPTION
## PR-01 — Onda 0: verdade do projeto

Esta PR alinha a apresentação pública e as fontes canônicas com o estado real do Microservice Shop antes de qualquer nova implementação.

### Mudanças
- reposiciona o README como plataforma de processamento de pedidos orientada a eventos;
- separa claramente capacidades implementadas de capacidades planejadas;
- substitui o roadmap datado de 2024 por ondas técnicas sem datas artificiais;
- redefine visão/objetivo em torno de confiabilidade distribuída, não de “demonstrar tecnologias”;
- atualiza escopo real e limitações conhecidas;
- torna a arquitetura atual explícita e separada da arquitetura-alvo;
- corrige a afirmação de Clean Architecture estrita;
- marca documentos antigos de próximos passos, reestruturação e estágio como históricos/não canônicos;
- separa ML clássico implementado de LLM ainda não implementado.

### Não altera
- runtime;
- RabbitMQ;
- banco;
- worker;
- CI;
- testes.

### Referência
Segue a auditoria e o plano aceitos em `docs/05-evolucao/`.