### PR TITLE
docs: establish event contracts and reliability ADRs

### DIFF
--- a/contracts/asyncapi.yaml
+++ b/contracts/asyncapi.yaml
@@ -1,0 +1,33 @@
+asyncapi: 3.0.0
+info:
+  title: Microservice Shop Events
+  version: 1.0.0
+  description: >-
+    Contract baseline for Microservice Shop domain events. This document defines
+    the target order.created.v1 contract before runtime adoption.
+channels:
+  orderCreatedV1:
+    address: orders.events
+    messages:
+      orderCreatedV1:
+        $ref: '#/components/messages/OrderCreatedV1'
+operations:
+  publishOrderCreatedV1:
+    action: send
+    channel:
+      $ref: '#/channels/orderCreatedV1'
+    messages:
+      - $ref: '#/channels/orderCreatedV1/messages/orderCreatedV1'
+components:
+  messages:
+    OrderCreatedV1:
+      name: order.created.v1
+      title: Order created event v1
+      summary: Emitted after an order and its outbox record are committed.
+      contentType: application/json
+      payload:
+        $ref: './events/order-created-v1.schema.json'
+      bindings:
+        amqp:
+          routingKey: order.created.v1
+          bindingVersion: 0.3.0

--- a/contracts/asyncapi.yaml
+++ b/contracts/asyncapi.yaml
@@ -7,7 +7,10 @@ info:
     the target order.created.v1 contract before runtime adoption.
 channels:
   orderCreatedV1:
-    address: orders.events
+    address: order.created.v1
+    description: >-
+      Versioned order-created event routed through the orders.events exchange
+      by the RabbitMQ implementation.
     messages:
       orderCreatedV1:
         $ref: '#/components/messages/OrderCreatedV1'
@@ -27,7 +30,3 @@ components:
       contentType: application/json
       payload:
         $ref: './events/order-created-v1.schema.json'
-      bindings:
-        amqp:
-          routingKey: order.created.v1
-          bindingVersion: 0.3.0

--- a/contracts/events/order-created-v1.schema.json
+++ b/contracts/events/order-created-v1.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://microservice-shop.local/contracts/events/order-created-v1.schema.json",
+  "title": "OrderCreatedV1",
+  "description": "Target contract for the versioned order.created event. Runtime adoption is implemented in a later architecture PR.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "eventId",
+    "eventType",
+    "eventVersion",
+    "occurredAt",
+    "correlationId",
+    "payload"
+  ],
+  "properties": {
+    "eventId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "eventType": {
+      "const": "order.created"
+    },
+    "eventVersion": {
+      "const": 1
+    },
+    "occurredAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "correlationId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["orderId", "productId", "quantity", "status"],
+      "properties": {
+        "orderId": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "productId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "quantity": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "status": {
+          "const": "PENDING"
+        }
+      }
+    }
+  }
+}

--- a/docs/02-arquitetura/decisoes/ADR-003-transactional-outbox.md
+++ b/docs/02-arquitetura/decisoes/ADR-003-transactional-outbox.md
@@ -1,0 +1,86 @@
+# ADR-003: Transactional Outbox para publicação de eventos
+
+**Status:** Aceita para implementação  
+**Data:** 2026-08-19
+
+## Contexto
+
+O fluxo atual salva o pedido e publica `order.created` em operações independentes. Quando um banco real for introduzido, uma falha entre essas operações poderá deixar um pedido persistido sem o evento correspondente.
+
+Uma transação distribuída entre PostgreSQL e RabbitMQ aumentaria muito a complexidade e não é necessária para este projeto.
+
+## Decisão
+
+Persistir `Order` e `OutboxEvent` na **mesma transação PostgreSQL**.
+
+Um publisher separado deve:
+
+1. consultar eventos pendentes;
+2. publicar o evento no RabbitMQ;
+3. marcar o registro como publicado somente após sucesso;
+4. manter o evento pendente quando a publicação falhar.
+
+A janela entre publicar no broker e atualizar `published_at` permite publicação duplicada. Isso é aceito explicitamente.
+
+## Consequência arquitetural
+
+O sistema adota:
+
+```text
+atomicidade local no PostgreSQL
++ publicação eventual
++ entrega at-least-once
++ consumidores idempotentes
+```
+
+Não é objetivo implementar exactly-once delivery.
+
+## Estrutura mínima
+
+A tabela `outbox_events` deve registrar, no mínimo:
+
+- `id`;
+- `aggregate_type`;
+- `aggregate_id`;
+- `event_type`;
+- `event_version`;
+- `correlation_id`;
+- `payload`;
+- `occurred_at`;
+- `published_at`;
+- `attempts`.
+
+## Alternativas consideradas
+
+### Publicar diretamente depois de `repository.save`
+
+Rejeitada porque mantém o problema de dual write.
+
+### Publicar antes de salvar
+
+Rejeitada porque permite evento existir sem estado persistido correspondente.
+
+### Transação distribuída/2PC
+
+Rejeitada pelo custo operacional e complexidade desproporcionais ao problema.
+
+## Consequências
+
+**Positivas**
+
+- pedido e intenção de publicação são atômicos;
+- falha do RabbitMQ não perde o evento;
+- comportamento pode ser testado com banco real;
+- decisão é compatível com processamento at-least-once.
+
+**Negativas**
+
+- publicação deixa de ser instantaneamente acoplada à requisição;
+- exige publisher e política para eventos pendentes;
+- consumidores precisam tolerar duplicidade.
+
+## Relações
+
+- substitui a estratégia de publicação direta como desenho-alvo;
+- complementa o ADR-004 sobre at-least-once, retry e DLQ;
+- contrato-alvo: `contracts/events/order-created-v1.schema.json`.

--- a/docs/02-arquitetura/decisoes/ADR-004-at-least-once-retry-dlq.md
+++ b/docs/02-arquitetura/decisoes/ADR-004-at-least-once-retry-dlq.md
@@ -1,0 +1,112 @@
+# ADR-004: At-least-once, retry com atraso e Dead Letter Queue
+
+**Status:** Aceita para implementação  
+**Data:** 2026-08-19
+
+## Contexto
+
+O `scheduler-agent` atual confirma a mensagem no `finally`, mesmo quando a chamada HTTP pode falhar. Isso permite perda silenciosa do trabalho.
+
+Além disso, a topologia atual não diferencia falhas transitórias de mensagens definitivamente inválidas.
+
+## Decisão
+
+O consumidor do evento `order.created.v1` adota semântica **at-least-once**.
+
+### Sucesso
+
+HTTP 2xx na confirmação do pedido:
+
+- registrar sucesso;
+- ACK da mensagem.
+
+### Falha transitória
+
+Exemplos:
+
+- timeout;
+- connection error;
+- HTTP 5xx.
+
+Ação:
+
+- não considerar o efeito concluído;
+- NACK sem requeue imediato;
+- encaminhar para fila de retry com atraso;
+- retornar à fila principal após TTL;
+- limitar quantidade de tentativas.
+
+### Falha definitiva
+
+Exemplos:
+
+- JSON inválido;
+- contrato incompatível;
+- campos obrigatórios ausentes;
+- HTTP 4xx classificado como não recuperável.
+
+Ação:
+
+- enviar para DLQ;
+- preservar payload e metadados;
+- ACK da mensagem original apenas depois de a transferência ser aceita pelo broker.
+
+### Retries esgotados
+
+- enviar para DLQ;
+- registrar número de tentativas e motivo final.
+
+## Topologia-alvo
+
+```text
+exchange: orders.events
+routing key: order.created.v1
+
+scheduler-agent
+├── queue: scheduler.order-created.v1
+├── retry: scheduler.order-created.retry.v1
+└── dlq:   scheduler.order-created.dlq.v1
+```
+
+A fila pertence ao consumidor. O produtor conhece apenas o contrato do evento e o exchange/routing key.
+
+## Idempotência
+
+At-least-once permite reentrega. Por isso, confirmar um pedido que já está `CONFIRMED` deve ser uma operação segura e sem efeito incorreto.
+
+A primeira implementação pode garantir idempotência pelo estado de domínio do pedido. Se efeitos externos adicionais forem introduzidos no futuro, uma estratégia explícita de deduplicação por `eventId` deverá ser avaliada.
+
+## Alternativas consideradas
+
+### ACK sempre no final do callback
+
+Rejeitada porque falhas podem desaparecer sem reprocessamento.
+
+### `requeue=true` imediato
+
+Rejeitada porque pode criar hot loop durante indisponibilidade persistente.
+
+### Exactly-once
+
+Não adotada. RabbitMQ e chamadas HTTP entre processos tornam essa promessa inadequada sem complexidade desproporcional.
+
+## Consequências
+
+**Positivas**
+
+- falha transitória deixa evidência e pode ser recuperada;
+- mensagens inválidas não bloqueiam a fila principal;
+- comportamento fica testável;
+- semântica distribuída fica explícita.
+
+**Negativas**
+
+- consumidor precisa tolerar duplicidade;
+- topologia RabbitMQ fica mais rica;
+- retry/DLQ exigem operação e observabilidade.
+
+## Relações
+
+- depende do contrato `order.created.v1`;
+- complementa o ADR-003 de Transactional Outbox;
+- observabilidade deve registrar `eventId`, `correlationId`, `orderId`, tentativa e motivo de falha.

--- a/docs/02-arquitetura/decisoes/README.md
+++ b/docs/02-arquitetura/decisoes/README.md
@@ -1,7 +1,17 @@
 # Decisões de Arquitetura (ADRs)
 
 | ADR | Título | Status |
-|-----|--------|--------|
+|---|---|---|
 | ADR-000 | Template | Referência |
 | ADR-001 | RabbitMQ como mensageria | Aceita |
-| ADR-002 | InMemoryOrderRepository no MVP | Aceita |
+| ADR-002 | InMemoryOrderRepository no MVP | Aceita temporária / será substituída |
+| ADR-003 | Transactional Outbox para publicação de eventos | Aceita para implementação |
+| ADR-004 | At-least-once, retry com atraso e Dead Letter Queue | Aceita para implementação |
+
+## Leitura de status
+
+- **Aceita:** decisão refletida no estado atual ou mantida como fundamento.
+- **Aceita temporária:** decisão vigente apenas até a etapa de evolução indicada.
+- **Aceita para implementação:** arquitetura aprovada, mas ainda não deve ser descrita como runtime já concluído.
+
+A sequência de implementação está em [`../../05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md`](../../05-evolucao/PLANO_EVOLUCAO_ARQUITETURAL.md).


### PR DESCRIPTION
## PR-01B — fechamento da Onda 0

Complementa a PR-01 sem alterar runtime.

### Adiciona
- `contracts/events/order-created-v1.schema.json`;
- `contracts/asyncapi.yaml` em AsyncAPI 3.0;
- ADR-003: Transactional Outbox;
- ADR-004: at-least-once + retry com atraso + DLQ;
- índice de ADRs com status explícito entre decisão vigente e decisão aceita para implementação.

### Regra importante
O contrato `order.created.v1`, Outbox e retry/DLQ estão **aprovados como alvo**, mas não são apresentados como runtime já implementado.

Depois desta PR, a Onda 0 fica fechada e a PR-02 pode tratar exclusivamente de domínio + PostgreSQL.