### PR TITLE
fix: bound scheduler confirmation request time

### DIFF
--- a/services/workers/scheduler-agent/app.py
+++ b/services/workers/scheduler-agent/app.py
@@ -6,6 +6,7 @@ import requests
 
 RABBIT_URL = os.environ.get("RABBIT_URL", "amqp://guest:guest@localhost:5672")
 ORDER_URL = os.environ.get("ORDER_URL", "http://localhost:8080")
+REQUEST_TIMEOUT_SECONDS = float(os.environ.get("REQUEST_TIMEOUT_SECONDS", "5"))
 QUEUE_NAME = "order.created"
 
 
@@ -15,7 +16,10 @@ def on_message(channel, method, properties, body):
         order_id = data.get("id")
         if not order_id:
             return
-        requests.post(f"{ORDER_URL}/orders/{order_id}/confirm")
+        requests.post(
+            f"{ORDER_URL}/orders/{order_id}/confirm",
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
     finally:
         channel.basic_ack(delivery_tag=method.delivery_tag)
 

--- a/services/workers/scheduler-agent/tests/test_app.py
+++ b/services/workers/scheduler-agent/tests/test_app.py
@@ -9,7 +9,7 @@ def _method(tag: str) -> SimpleNamespace:
     return SimpleNamespace(delivery_tag=tag)
 
 
-def test_on_message_posts_confirmation_request(monkeypatch):
+def test_on_message_posts_confirmation_request_with_timeout(monkeypatch):
     channel = MagicMock()
     method = _method("delivery")
     order_id = "order-1"
@@ -20,7 +20,10 @@ def test_on_message_posts_confirmation_request(monkeypatch):
 
     app.on_message(channel, method, None, body)
 
-    post_mock.assert_called_once_with(f"{app.ORDER_URL}/orders/{order_id}/confirm")
+    post_mock.assert_called_once_with(
+        f"{app.ORDER_URL}/orders/{order_id}/confirm",
+        timeout=app.REQUEST_TIMEOUT_SECONDS,
+    )
     channel.basic_ack.assert_called_once_with(delivery_tag="delivery")
 
 


### PR DESCRIPTION
## Security prerequisite

Corrige isoladamente o achado Bandit B113 que já existia na `main` antes da evolução PostgreSQL.

### Mudança
- adiciona `REQUEST_TIMEOUT_SECONDS` configurável (default 5s);
- passa timeout explícito para `requests.post`;
- atualiza o teste unitário para provar o contrato.

### Deliberadamente não muda
- ACK no `finally`;
- retry/DLQ;
- topologia RabbitMQ;
- formato do evento.

Essas mudanças maiores continuam reservadas para a PR de semântica at-least-once.